### PR TITLE
Implement timeout / cancellation example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,10 +227,15 @@ add_executable(prio
 )
 target_link_libraries(prio ${LIBURING_LIBRARY})
 
-add_executable(delay
+add_executable(asio_cancellation
+    examples/asio/cancellation.cpp
+)
+target_link_libraries(asio_cancellation ${LIBURING_LIBRARY})
+
+add_executable(asio_delay
     examples/asio/delay.cpp
 )
-target_link_libraries(delay ${LIBURING_LIBRARY})
+target_link_libraries(asio_delay ${LIBURING_LIBRARY})
 
 add_executable(asio_http_server
     examples/asio/http_server.cpp
@@ -280,7 +285,14 @@ add_custom_command(TARGET braid POST_BUILD
     ${CMAKE_CURRENT_LIST_DIR}/build
 )
 
-add_custom_command(TARGET delay POST_BUILD
+
+add_custom_command(TARGET asio_cancellation POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${CMAKE_BINARY_DIR}/compile_commands.json
+    ${CMAKE_CURRENT_LIST_DIR}/build
+)
+
+add_custom_command(TARGET asio_delay POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
     ${CMAKE_BINARY_DIR}/compile_commands.json
     ${CMAKE_CURRENT_LIST_DIR}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,10 +222,10 @@ add_executable(spawn_iterator
     examples/spawn_iterator.cpp
 )
 
-add_executable(prio
+add_executable(asio_prio
     examples/asio/prio.cpp
 )
-target_link_libraries(prio ${LIBURING_LIBRARY})
+target_link_libraries(asio_prio ${LIBURING_LIBRARY})
 
 add_executable(asio_cancellation
     examples/asio/cancellation.cpp
@@ -285,7 +285,6 @@ add_custom_command(TARGET braid POST_BUILD
     ${CMAKE_CURRENT_LIST_DIR}/build
 )
 
-
 add_custom_command(TARGET asio_cancellation POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
     ${CMAKE_BINARY_DIR}/compile_commands.json
@@ -293,6 +292,12 @@ add_custom_command(TARGET asio_cancellation POST_BUILD
 )
 
 add_custom_command(TARGET asio_delay POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    ${CMAKE_BINARY_DIR}/compile_commands.json
+    ${CMAKE_CURRENT_LIST_DIR}/build
+)
+
+add_custom_command(TARGET asio_prio POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
     ${CMAKE_BINARY_DIR}/compile_commands.json
     ${CMAKE_CURRENT_LIST_DIR}/build

--- a/examples/alignment.cpp
+++ b/examples/alignment.cpp
@@ -3,7 +3,8 @@
 // Clang <16 does not obey alignment when creating coroutine frames
 // https://github.com/llvm/llvm-project/issues/56671
 // This test seems to reproduce the failure in Debug mode at least
-// In Clang 16 you must supply `-fcoro-aligned-allocation` to fix it.
+// In Clang versions 16 or higher you must supply `-fcoro-aligned-allocation`
+// to fix it.
 
 // Bug also exists in GCC 13
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=104177

--- a/examples/asio/cancellation.cpp
+++ b/examples/asio/cancellation.cpp
@@ -18,7 +18,6 @@
 #include "tmc/ex_cpu.hpp"
 #include "tmc/external.hpp"
 #include "tmc/spawn_task_tuple.hpp"
-#include "tmc/spawn_task_tuple_each.hpp"
 
 #include <asio/steady_timer.hpp>
 #include <chrono>

--- a/examples/asio/cancellation.cpp
+++ b/examples/asio/cancellation.cpp
@@ -1,0 +1,76 @@
+// Demonstrate the timer / delay capabilities of Asio executor
+// Use resume_on() to send the task back and forth
+// between asio_executor() and cpu_executor()
+
+#include <asio/error.hpp>
+#define TMC_IMPL
+
+#include "asio_thread_name.hpp"
+
+#include "tmc/asio/aw_asio.hpp"
+#include "tmc/asio/ex_asio.hpp"
+#include "tmc/ex_cpu.hpp"
+#include "tmc/external.hpp"
+#include "tmc/spawn_task_tuple.hpp"
+#include "tmc/spawn_task_tuple_each.hpp"
+
+#include <asio/steady_timer.hpp>
+#include <chrono>
+#include <cstdio>
+
+int main() {
+  hook_init_ex_cpu_thread_name(tmc::cpu_executor());
+  hook_init_ex_asio_thread_name(tmc::asio_executor());
+  tmc::asio_executor().init();
+  return tmc::async_main([]() -> tmc::task<int> {
+    print_thread_name();
+    for (size_t i = 0; i < 3; ++i) {
+      asio::steady_timer tim{
+        tmc::asio_executor(), std::chrono::milliseconds(250)
+      };
+      // this demonstrates early cancellation
+      auto mainTask = tmc::external::to_task<std::tuple<asio::error_code>>(
+        tim.async_wait(tmc::aw_asio)
+      );
+      auto timeoutTask = [](asio::steady_timer& Tim) -> tmc::task<void> {
+        asio::steady_timer shortTim{
+          tmc::asio_executor(), std::chrono::milliseconds(100)
+        };
+        auto [error] = co_await shortTim.async_wait(tmc::aw_asio)
+                         .resume_on(tmc::asio_executor());
+        Tim.cancel();
+      }(tim);
+      auto waitGroup =
+        tmc::spawn_tuple(std::move(mainTask), std::move(timeoutTask)).each();
+      for (auto readyIdx = co_await waitGroup; readyIdx != waitGroup.end();
+           readyIdx = co_await waitGroup) {
+        switch (readyIdx) {
+        case 0: {
+          auto [ec] = waitGroup.get<0>();
+          switch (ec.value()) {
+          case asio::error::operation_aborted:
+            std::printf("operation was canceled\n");
+            break;
+          case 0:
+            std::printf("timer ran to completion\n");
+            break;
+          default:
+            std::printf(
+              "an unexpected error occurred: %d | %s\n", ec.value(),
+              ec.message().c_str()
+            );
+            break;
+          }
+          break;
+        }
+        case 1: {
+          std::printf("timeout occurred\n");
+          tim.cancel();
+          break;
+        }
+        }
+      }
+    }
+    co_return 0;
+  }());
+}

--- a/examples/asio/cancellation.cpp
+++ b/examples/asio/cancellation.cpp
@@ -10,6 +10,11 @@
 // reference to the long-running operation and cancel it directly after the
 // timer expires.
 
+// Note: Asio already exposes timeout functions for some operations which are
+// probably easier/more performant when available. This example is only to
+// demonstrate how you might build a timeout/cancellation primitive from scratch
+// for another type of awaitable.
+
 #include <asio/error.hpp>
 #define TMC_IMPL
 

--- a/examples/asio/cancellation.cpp
+++ b/examples/asio/cancellation.cpp
@@ -1,11 +1,17 @@
-// Demonstrate the timer / delay capabilities of Asio executor
-// Use resume_on() to send the task back and forth
-// between asio_executor() and cpu_executor()
+// Demonstrate how to use tmc::spawn_tuple().each() to await heterogeneous tasks
+// that complete at different times. By submitting a long-running task and a
+// short running timer, timeout-based cancellation can be achieved.
+
+// The timeout nominally occurs after 100ms and the timestamps of the various
+// events are logged. Note that the this example signals the cancellation event
+// back to the root task by the completion of the timeout operation (at index
+// 1 in the tuple), and then the root task cancels the long-running operation.
+// This is somewhat less efficient than having the timeout task capture a
+// reference to the long-running operation and cancel it directly after the
+// timer expires.
 
 #include <asio/error.hpp>
 #define TMC_IMPL
-
-#include "asio_thread_name.hpp"
 
 #include "tmc/asio/aw_asio.hpp"
 #include "tmc/asio/ex_asio.hpp"
@@ -18,58 +24,89 @@
 #include <chrono>
 #include <cstdio>
 
+void log_event_timestamp(
+  std::string event, std::chrono::high_resolution_clock::time_point startTime,
+  std::chrono::high_resolution_clock::time_point now =
+    std::chrono::high_resolution_clock::now()
+) {
+  std::printf(
+    "%s at %" PRIu64 " us\n", event.c_str(),
+    std::chrono::duration_cast<std::chrono::microseconds>(now - startTime)
+      .count()
+  );
+}
+
+void log_error_code(
+  asio::error_code ec, std::chrono::high_resolution_clock::time_point startTime
+) {
+  switch (ec.value()) {
+  case 0:
+    log_event_timestamp("operation completed", startTime);
+    break;
+  case asio::error::operation_aborted:
+    log_event_timestamp("operation canceled", startTime);
+    break;
+  default:
+    std::printf(
+      "an unexpected error occurred: %d | %s\n", ec.value(),
+      ec.message().c_str()
+    );
+    break;
+  }
+}
+
 int main() {
-  hook_init_ex_cpu_thread_name(tmc::cpu_executor());
-  hook_init_ex_asio_thread_name(tmc::asio_executor());
   tmc::asio_executor().init();
   return tmc::async_main([]() -> tmc::task<int> {
-    print_thread_name();
     for (size_t i = 0; i < 3; ++i) {
-      asio::steady_timer tim{
-        tmc::asio_executor(), std::chrono::milliseconds(250)
+      auto startTime = std::chrono::high_resolution_clock::now();
+      // The main task could be a network operation, but is simulated here using
+      // a long-running timer
+      asio::steady_timer mainOperationHandle{
+        tmc::asio_executor(), std::chrono::milliseconds(1000)
       };
-      // this demonstrates early cancellation
       auto mainTask = tmc::external::to_task<std::tuple<asio::error_code>>(
-        tim.async_wait(tmc::aw_asio)
+        mainOperationHandle.async_wait(tmc::aw_asio)
       );
-      auto timeoutTask = [](asio::steady_timer& Tim) -> tmc::task<void> {
+
+      // A shorter timer is used for the timeout
+      auto timeoutTask =
+        []() -> tmc::task<std::chrono::high_resolution_clock::time_point> {
         asio::steady_timer shortTim{
           tmc::asio_executor(), std::chrono::milliseconds(100)
         };
         auto [error] = co_await shortTim.async_wait(tmc::aw_asio)
                          .resume_on(tmc::asio_executor());
-        Tim.cancel();
-      }(tim);
-      auto waitGroup =
+        co_return std::chrono::high_resolution_clock::now();
+      }();
+
+      // Using the each() customizer allows us to receive each result
+      // immediately as it becomes ready, even if the other tasks are still
+      // running
+      auto eachResult =
         tmc::spawn_tuple(std::move(mainTask), std::move(timeoutTask)).each();
-      for (auto readyIdx = co_await waitGroup; readyIdx != waitGroup.end();
-           readyIdx = co_await waitGroup) {
+
+      for (auto readyIdx = co_await eachResult; readyIdx != eachResult.end();
+           readyIdx = co_await eachResult) {
         switch (readyIdx) {
         case 0: {
-          auto [ec] = waitGroup.get<0>();
-          switch (ec.value()) {
-          case asio::error::operation_aborted:
-            std::printf("operation was canceled\n");
-            break;
-          case 0:
-            std::printf("timer ran to completion\n");
-            break;
-          default:
-            std::printf(
-              "an unexpected error occurred: %d | %s\n", ec.value(),
-              ec.message().c_str()
-            );
-            break;
-          }
+          // The main task is ready - check its error code to see how it
+          // finished
+          auto [ec] = eachResult.get<0>();
+          log_error_code(ec, startTime);
           break;
         }
         case 1: {
-          std::printf("timeout occurred\n");
-          tim.cancel();
+          // The timeout task is ready; now cancel the main task
+          auto timeoutAt = eachResult.get<1>();
+          log_event_timestamp("timeout occurred", startTime, timeoutAt);
+          mainOperationHandle.cancel();
+          log_event_timestamp("cancellation signaled", startTime);
           break;
         }
         }
       }
+      std::printf("\n");
     }
     co_return 0;
   }());

--- a/examples/asio/delay.cpp
+++ b/examples/asio/delay.cpp
@@ -19,18 +19,6 @@ int main() {
   hook_init_ex_asio_thread_name(tmc::asio_executor());
   tmc::asio_executor().init();
   return tmc::async_main([]() -> tmc::task<int> {
-    // Uncomment this to spawn 1000000 tasks and observe the RAM usage
-    // also needs #include "tmc/spawn_many.hpp" and #include <ranges>
-    // auto tasks = std::ranges::views::iota(0, 1000000) |
-    //              std::ranges::views::transform([](int i) -> tmc::task<void> {
-    //                co_await asio::steady_timer{
-    //                  tmc::asio_executor(), std::chrono::seconds(20)
-    //                }
-    //                  .async_wait(tmc::aw_asio);
-    //                co_return;
-    //              });
-    // co_await tmc::spawn_many(tasks.begin(), tasks.end());
-
     print_thread_name();
     for (size_t i = 0; i < 8; ++i) {
       asio::steady_timer tim{

--- a/examples/asio/delay.cpp
+++ b/examples/asio/delay.cpp
@@ -24,16 +24,6 @@ int main() {
       asio::steady_timer tim{
         tmc::asio_executor(), std::chrono::milliseconds(250)
       };
-      // // this demonstrates early cancellation
-      // tmc::spawn([](asio::steady_timer& Tim) -> tmc::task<void> {
-      //   asio::steady_timer shortTim{
-      //     tmc::asio_executor(), std::chrono::milliseconds(100)
-      //   };
-      //   auto [error] = co_await shortTim.async_wait(tmc::aw_asio)
-      //                    .resume_on(tmc::asio_executor());
-      //   Tim.cancel();
-      // }(tim))
-      //   .detach();
       auto [error] =
         co_await tim.async_wait(tmc::aw_asio).resume_on(tmc::asio_executor());
       if (error) {
@@ -41,7 +31,7 @@ int main() {
         co_return -1;
       }
       print_thread_name();
-      // co_await tmc::delay(std::chrono::milliseconds(250));
+
       auto [error2] =
         co_await asio::steady_timer{
           tmc::asio_executor(), std::chrono::milliseconds(250)

--- a/examples/fib.cpp
+++ b/examples/fib.cpp
@@ -9,7 +9,6 @@
 #include <chrono>
 #include <cinttypes>
 #include <cstdio>
-#include <ranges>
 
 using namespace tmc;
 

--- a/examples/fib.cpp
+++ b/examples/fib.cpp
@@ -41,9 +41,7 @@ static task<size_t> fib(size_t n) {
   //                                         .begin());
   // co_return results[0] + results[1];
 
-  auto tasks = co_await spawn_tuple(fib(n - 1), fib(n - 2));
-  auto x = std::get<0>(tasks);
-  auto y = std::get<1>(tasks);
+  auto [x, y] = co_await spawn_tuple(fib(n - 1), fib(n - 2));
 
   /* Spawn one, then serially execute the other, then await the first */
   // auto xt = spawn(fib(n - 1)).run_early();

--- a/examples/fib.cpp
+++ b/examples/fib.cpp
@@ -41,13 +41,15 @@ static task<size_t> fib(size_t n) {
   //                                         .begin());
   // co_return results[0] + results[1];
 
+  // Submit using variadic parameter pack, and get the results as a tuple
   auto [x, y] = co_await spawn_tuple(fib(n - 1), fib(n - 2));
+  co_return x + y;
 
   /* Spawn one, then serially execute the other, then await the first */
   // auto xt = spawn(fib(n - 1)).run_early();
   // auto y = co_await fib(n - 2);
   // auto x = co_await std::move(xt);
-  co_return x + y;
+  // co_return x + y;
 }
 
 static task<void> top_fib(size_t n) {

--- a/examples/fib.cpp
+++ b/examples/fib.cpp
@@ -46,7 +46,7 @@ static task<size_t> fib(size_t n) {
   // auto x = co_await std::move(xt);
   // co_return x + y;
 
-  // Submit using variadic parameter pack, and get the results as a tuple
+  /* Submit using variadic parameter pack, and get the results as a tuple */
   auto [x, y] = co_await spawn_tuple(fib(n - 1), fib(n - 2));
   co_return x + y;
 }

--- a/examples/fib.cpp
+++ b/examples/fib.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <cinttypes>
 #include <cstdio>
+#include <ranges>
 
 using namespace tmc;
 
@@ -40,10 +41,14 @@ static task<size_t> fib(size_t n) {
   //                                         .begin());
   // co_return results[0] + results[1];
 
+  auto tasks = co_await spawn_tuple(fib(n - 1), fib(n - 2));
+  auto x = std::get<0>(tasks);
+  auto y = std::get<1>(tasks);
+
   /* Spawn one, then serially execute the other, then await the first */
-  auto xt = spawn(fib(n - 1)).run_early();
-  auto y = co_await fib(n - 2);
-  auto x = co_await std::move(xt);
+  // auto xt = spawn(fib(n - 1)).run_early();
+  // auto y = co_await fib(n - 2);
+  // auto x = co_await std::move(xt);
   co_return x + y;
 }
 

--- a/examples/fib.cpp
+++ b/examples/fib.cpp
@@ -40,15 +40,15 @@ static task<size_t> fib(size_t n) {
   //                                         .begin());
   // co_return results[0] + results[1];
 
-  // Submit using variadic parameter pack, and get the results as a tuple
-  auto [x, y] = co_await spawn_tuple(fib(n - 1), fib(n - 2));
-  co_return x + y;
-
   /* Spawn one, then serially execute the other, then await the first */
   // auto xt = spawn(fib(n - 1)).run_early();
   // auto y = co_await fib(n - 2);
   // auto x = co_await std::move(xt);
   // co_return x + y;
+
+  // Submit using variadic parameter pack, and get the results as a tuple
+  auto [x, y] = co_await spawn_tuple(fib(n - 1), fib(n - 2));
+  co_return x + y;
 }
 
 static task<void> top_fib(size_t n) {

--- a/examples/skynet/skynet_coro_bulk.hpp
+++ b/examples/skynet/skynet_coro_bulk.hpp
@@ -35,18 +35,15 @@ tmc::task<size_t> skynet_one(size_t BaseNum, size_t Depth) {
   // tmc::spawn_many<10>(children.data());
 
   /// Construction from a sized iterator has slightly better performance
-  auto results =
-    tmc::spawn_many<10>(
-      (std::ranges::views::iota(0UL) |
-       std::ranges::views::transform([=](size_t idx) {
-         return skynet_one<DepthMax>(BaseNum + depthOffset * idx, Depth + 1);
-       })
-      ).begin()
-    )
-      .each();
+  std::array<size_t, 10> results = co_await tmc::spawn_many<10>(
+    (std::ranges::views::iota(0UL) |
+     std::ranges::views::transform([=](size_t idx) {
+       return skynet_one<DepthMax>(BaseNum + depthOffset * idx, Depth + 1);
+     })
+    ).begin()
+  );
 
-  for (size_t idx = co_await results; idx != results.end();
-       idx = co_await results) {
+  for (size_t idx = 0; idx < 10; ++idx) {
     count += results[idx];
   }
   co_return count;

--- a/examples/skynet/skynet_coro_bulk.hpp
+++ b/examples/skynet/skynet_coro_bulk.hpp
@@ -35,15 +35,18 @@ tmc::task<size_t> skynet_one(size_t BaseNum, size_t Depth) {
   // tmc::spawn_many<10>(children.data());
 
   /// Construction from a sized iterator has slightly better performance
-  std::array<size_t, 10> results = co_await tmc::spawn_many<10>(
-    (std::ranges::views::iota(0UL) |
-     std::ranges::views::transform([=](size_t idx) {
-       return skynet_one<DepthMax>(BaseNum + depthOffset * idx, Depth + 1);
-     })
-    ).begin()
-  );
+  auto results =
+    tmc::spawn_many<10>(
+      (std::ranges::views::iota(0UL) |
+       std::ranges::views::transform([=](size_t idx) {
+         return skynet_one<DepthMax>(BaseNum + depthOffset * idx, Depth + 1);
+       })
+      ).begin()
+    )
+      .each();
 
-  for (size_t idx = 0; idx < 10; ++idx) {
+  for (size_t idx = co_await results; idx != results.end();
+       idx = co_await results) {
     count += results[idx];
   }
   co_return count;


### PR DESCRIPTION
Demonstrate capabilities of https://github.com/tzcnt/TooManyCooks/pull/18

- Implement examples/asio/cancellation.cpp
- Update examples/fib.cpp to use the variadic parameter / tuple destructuring syntax

Also cleanup examples/asio/prio.cpp - replace the hacky 5 second wait with a proper wait group

Rename all asio examples to prefix with asio_