### PR TITLE
disable exceptions with GCC and clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ else()
     CPMAddPackage(
         NAME TooManyCooks
         GIT_REPOSITORY https://github.com/tzcnt/TooManyCooks.git
-        GIT_TAG 1c1efb13be569e8d2b5fe061e90634f42536ea3a
+        GIT_TAG c92268634bed03721aad4c72f8f6ea11fb26d13c
         DOWNLOAD_ONLY)
 
     CPMAddPackage(

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,7 +31,7 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
-        "CMAKE_CXX_FLAGS": "-DTMC_TRIVIAL_TASK",
+        "CMAKE_CXX_FLAGS": "-DTMC_TRIVIAL_TASK -fno-exceptions",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       },
       "condition": {
@@ -51,6 +51,7 @@
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_CXX_FLAGS": "-fno-exceptions",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       },
       "condition": {
@@ -89,7 +90,7 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_C_COMPILER": "gcc",
         "CMAKE_CXX_COMPILER": "g++",
-        "CMAKE_CXX_FLAGS": "-DTMC_TRIVIAL_TASK",
+        "CMAKE_CXX_FLAGS": "-DTMC_TRIVIAL_TASK -fno-exceptions",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       },
       "condition": {
@@ -109,6 +110,7 @@
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "CMAKE_C_COMPILER": "gcc",
         "CMAKE_CXX_COMPILER": "g++",
+        "CMAKE_CXX_FLAGS": "-fno-exceptions",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
       },
       "condition": {

--- a/examples/external_coro.hpp
+++ b/examples/external_coro.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <coroutine>
+#include <exception>
 #include <utility>
 
 // A simple "external" awaitable coroutine type that has no knowledge of TMC.
@@ -41,7 +42,7 @@ template <typename Result> struct external_coro_promise {
   external_coro<Result> get_return_object() noexcept {
     return {external_coro<Result>::from_promise(*this)};
   }
-  void unhandled_exception() { throw; }
+  void unhandled_exception() { std::terminate(); }
   void return_value(Result&& Value) { *result_ptr = std::move(Value); }
   void return_value(const Result& Value) { *result_ptr = Value; }
   std::coroutine_handle<> continuation;
@@ -55,7 +56,7 @@ template <> struct external_coro_promise<void> {
   external_coro<void> get_return_object() noexcept {
     return {external_coro<void>::from_promise(*this)};
   }
-  [[noreturn]] void unhandled_exception() { throw; }
+  void unhandled_exception() { std::terminate(); }
   void return_void() {}
   std::coroutine_handle<> continuation;
 };


### PR DESCRIPTION
Throwing exceptions from coroutines is not supported at this time (see https://github.com/tzcnt/TooManyCooks/pull/24). So set -fno-exceptions in the example CMakePresets.