### PR TITLE
Implement "await_callback" example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,10 @@ add_executable(equilibrium
     examples/equilibrium.cpp
 )
 
+add_executable(callback_awaitable
+    examples/callback_awaitable.cpp
+)
+
 add_executable(external_coro
     examples/external_coro.cpp
 )

--- a/examples/callback_awaitable.cpp
+++ b/examples/callback_awaitable.cpp
@@ -1,0 +1,68 @@
+// Example of transforming a callback-based async API into a TMC awaitable.
+// Generic implementation is in callback_awaitable.hpp.
+
+#define TMC_IMPL
+
+#include "callback_awaitable.hpp"
+#include "tmc/ex_cpu.hpp"
+
+// Examples of callback-based async functions that might be provided by an
+// external library.
+void simulated_async_fn_void(void* user_data, void (*callback)(void*)) {
+  callback(user_data);
+}
+
+void simulated_async_fn(
+  void* user_data, void (*callback)(void*, float, float), int input
+) {
+  auto f = static_cast<float>(input);
+  callback(user_data, f + 1.0f, f + 2.0f);
+}
+
+void simulated_async_fn2(
+  void* user_data, void (*callback)(void*, int), float input1, float input2
+) {
+  auto result = static_cast<int>(input1 + input2);
+  callback(user_data, result);
+}
+
+// Demonstrate returning a move-only type from the awaitable.
+struct move_only_type {
+  int value;
+
+  move_only_type(int input) : value(input) {}
+  move_only_type& operator=(move_only_type&&) = default;
+  move_only_type(move_only_type&&) = default;
+  ~move_only_type() = default;
+
+  // No default or copy constructor
+  move_only_type() = delete;
+  move_only_type(const move_only_type&) = delete;
+  move_only_type& operator=(const move_only_type&) = delete;
+};
+
+void simulated_async_fn_move_only(
+  void* user_data, void (*callback)(void*, move_only_type), int input
+) {
+  callback(user_data, move_only_type{input + 1});
+}
+
+// Demonstrate usages of these functions with the callback_awaitable wrapper.
+int main() {
+  tmc::async_main([]() -> tmc::task<int> {
+    co_await await_callback(simulated_async_fn_void);
+
+    auto [result1, result2] = co_await await_callback(simulated_async_fn, 1);
+    assert(result1 == 2.0f);
+    assert(result2 == 3.0f);
+
+    auto [result] = co_await await_callback(simulated_async_fn2, 4.0f, 6.0f);
+    assert(result == 10);
+
+    auto aw = await_callback(simulated_async_fn_move_only, 1);
+    auto [move_only_result] = co_await aw;
+    assert(move_only_result.value == 2);
+
+    co_return 0;
+  }());
+}

--- a/examples/callback_awaitable.hpp
+++ b/examples/callback_awaitable.hpp
@@ -28,6 +28,10 @@
 #include <tuple>
 #include <utility>
 
+namespace tmc::detail {
+struct AwCallbackTag {};
+} // namespace tmc::detail
+
 template <typename Awaitable> struct callback_awaitable_impl {
   // Keep an lvalue reference to handle. Depends on temporary lifetime extension
   // when used in some contexts. Safe as long as you don't manually call
@@ -95,7 +99,8 @@ public:
 template <typename... ResultArgs> struct wrapper {
   template <typename Init, typename... InitArgs>
   struct [[nodiscard]] callback_awaitable final
-      : public callback_awaitable_base<ResultArgs...> {
+      : public callback_awaitable_base<ResultArgs...>,
+        tmc::detail::AwCallbackTag {
     Init initiate_async_fn;
     std::tuple<InitArgs...> init_args;
 
@@ -138,7 +143,6 @@ auto await_callback(
   void (*async_func)(void*, CallbackFunc*, InitArgs...),
   InitArgs... async_init_args
 ) {
-  using callback_signature = func_params<CallbackFunc>;
   return []<typename... ResultArgs>(
            std::type_identity<std::tuple<void*, ResultArgs...>>,
            void (*fn)(void*, CallbackFunc*, InitArgs...), InitArgs... args
@@ -147,8 +151,57 @@ auto await_callback(
       void (*)(void*, CallbackFunc*, InitArgs...), InitArgs...>
     aw(fn, std::forward<InitArgs>(args)...);
     return aw;
-  }(std::type_identity<typename callback_signature::arg_tuple>{}, async_func,
-           std::forward<InitArgs>(async_init_args)...);
+  }(std::type_identity<typename func_params<CallbackFunc>::arg_tuple>{},
+           async_func, std::forward<InitArgs>(async_init_args)...);
 }
 
-// TODO implement tmc::detail::awaitable_traits
+// Implementation of tmc::detail::awaitable_traits which fully integrates this
+// awaitable type with the library.
+namespace tmc::detail {
+
+template <typename T>
+concept IsAwCallback = std::is_base_of_v<tmc::detail::AwCallbackTag, T>;
+
+template <IsAwCallback Awaitable> struct awaitable_traits<Awaitable> {
+  using result_type = typename Awaitable::ResultTuple;
+  using self_type = Awaitable;
+
+  // Values controlling the behavior when awaited directly in a tmc::task
+  static decltype(auto) get_awaiter(self_type&& awaitable) {
+    return std::forward<self_type>(awaitable).operator co_await();
+  }
+
+  // Values controlling the behavior when wrapped by a utility function
+  // such as tmc::spawn_*()
+  static constexpr configure_mode mode = ASYNC_INITIATE;
+  static void async_initiate(
+    self_type&& awaitable,
+    [[maybe_unused]] tmc::detail::type_erased_executor* Executor,
+    [[maybe_unused]] size_t Priority
+  ) {
+    awaitable.async_initiate();
+  }
+
+  static void set_result_ptr(
+    self_type& awaitable, tmc::detail::result_storage_t<result_type>* ResultPtr
+  ) {
+    awaitable.customizer.result_ptr = ResultPtr;
+  }
+
+  static void set_continuation(self_type& awaitable, void* Continuation) {
+    awaitable.customizer.continuation = Continuation;
+  }
+
+  static void set_continuation_executor(self_type& awaitable, void* ContExec) {
+    awaitable.customizer.continuation_executor = ContExec;
+  }
+
+  static void set_done_count(self_type& awaitable, void* DoneCount) {
+    awaitable.customizer.done_count = DoneCount;
+  }
+
+  static void set_flags(self_type& awaitable, uint64_t Flags) {
+    awaitable.customizer.flags = Flags;
+  }
+};
+} // namespace tmc::detail

--- a/examples/callback_awaitable.hpp
+++ b/examples/callback_awaitable.hpp
@@ -1,0 +1,154 @@
+// Turn an a callback-style async operation into a TMC awaitable.
+// The function callback_awaitable() expects the async operation initiation
+// function and the set of initiation arguments.
+// See the usage examples in callback_awaitable.cpp.
+
+// This operates on a particular kind of async operation which accepts a
+// `user_data` pointer and provides it back to the callback on completion.
+// It uses this pointer to store the awaitable information.
+
+// The async operation initiation function should be of the form:
+// void (*)(void* user_data, CallbackFunc*, InitArgs...)
+
+// Its CallbackFunc parameter should be of the form:
+// void (*)(void* user_data, ResultArgs...)
+
+// The result of the awaitable will be a std::tuple<ResultArgs...>.
+
+// This template isn't part of the core TMC library because it depends on the
+// parameter order of the initiation / callback functions. If you have a similar
+// use case, but the function parameters are reordered, you can repurpose this
+// by changing the signature of `initiate_async_fn` and `callback`.
+
+#include "tmc/detail/concepts.hpp"
+#include "tmc/detail/thread_locals.hpp"
+#include "tmc/task.hpp"
+
+#include <coroutine>
+#include <tuple>
+#include <utility>
+
+template <typename Awaitable> struct callback_awaitable_impl {
+  // Keep an lvalue reference to handle. Depends on temporary lifetime extension
+  // when used in some contexts. Safe as long as you don't manually call
+  // operator co_await() on a temporary and try to save this for later.
+  Awaitable& handle;
+  tmc::detail::result_storage_t<typename Awaitable::ResultTuple> result;
+
+  friend Awaitable;
+  callback_awaitable_impl(Awaitable& Handle) : handle(Handle) {}
+
+  bool await_ready() { return false; }
+
+  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
+  ) noexcept {
+    handle.customizer.continuation = Outer.address();
+    handle.customizer.result_ptr = &result;
+    handle.async_initiate();
+  }
+
+  auto await_resume() noexcept {
+    // Move the result out of the optional
+    // (returns tuple<Result>, not optional<tuple<Result>>)
+    if constexpr (std::is_default_constructible_v<
+                    typename Awaitable::ResultTuple>) {
+      return std::move(result);
+    } else {
+      return *std::move(result);
+    }
+  }
+};
+
+template <typename... ResultArgs> struct callback_awaitable_base {
+  using ResultTuple = std::tuple<ResultArgs...>;
+  tmc::detail::awaitable_customizer<ResultTuple> customizer;
+  size_t prio;
+
+  callback_awaitable_base() : prio(tmc::detail::this_thread::this_task.prio) {}
+
+  template <typename... ResultArgs_>
+  static inline void callback(void* user_data, ResultArgs_... results) {
+    auto aw = static_cast<callback_awaitable_base*>(user_data);
+    if constexpr (std::is_default_constructible_v<std::tuple<ResultArgs...>>) {
+      *aw->customizer.result_ptr =
+        std::tuple<ResultArgs...>(std::forward<ResultArgs_>(results)...);
+    } else {
+      aw->customizer.result_ptr->emplace(std::forward<ResultArgs_>(results)...);
+    }
+
+    auto next = aw->customizer.resume_continuation(aw->prio);
+    if (next != std::noop_coroutine()) {
+      next.resume();
+    }
+  }
+
+  virtual void async_initiate() = 0;
+
+public:
+  callback_awaitable_base(const callback_awaitable_base&) = default;
+  callback_awaitable_base(callback_awaitable_base&&) = default;
+  callback_awaitable_base& operator=(const callback_awaitable_base&) = default;
+  callback_awaitable_base& operator=(callback_awaitable_base&&) = default;
+  virtual ~callback_awaitable_base() = default;
+};
+
+template <typename... ResultArgs> struct wrapper {
+  template <typename Init, typename... InitArgs>
+  struct [[nodiscard]] callback_awaitable final
+      : public callback_awaitable_base<ResultArgs...> {
+    Init initiate_async_fn;
+    std::tuple<InitArgs...> init_args;
+
+    template <typename Init_, typename... InitArgs_>
+    callback_awaitable(Init_&& Initiation, InitArgs_&&... Args)
+        : initiate_async_fn(std::forward<Init_>(Initiation)),
+          init_args(std::forward<InitArgs_>(Args)...) {}
+
+    void async_initiate() final override {
+      std::apply(
+        [&](InitArgs&&... Args) {
+          std::move(initiate_async_fn)(
+            static_cast<callback_awaitable_base<ResultArgs...>*>(this),
+            &callback_awaitable_base<ResultArgs...>::callback,
+            std::move(Args)...
+          );
+        },
+        std::move(init_args)
+      );
+    }
+
+    callback_awaitable_impl<callback_awaitable> operator co_await() {
+      return callback_awaitable_impl<callback_awaitable>(*this);
+    }
+  };
+};
+
+template <typename S> struct func_params;
+
+template <typename Result, typename... Args>
+struct func_params<Result(Args...)> {
+  using result_type = Result;
+  using arg_tuple = typename std::tuple<Args...>;
+};
+
+// Constructor which produces an awaitable from external async function
+// pointer/args.
+template <typename CallbackFunc, typename... InitArgs>
+auto await_callback(
+  void (*async_func)(void*, CallbackFunc*, InitArgs...),
+  InitArgs... async_init_args
+) {
+  using callback_signature = func_params<CallbackFunc>;
+  return []<typename... ResultArgs>(
+           std::type_identity<std::tuple<void*, ResultArgs...>>,
+           void (*fn)(void*, CallbackFunc*, InitArgs...), InitArgs... args
+         ) -> auto {
+    typename wrapper<ResultArgs...>::template callback_awaitable<
+      void (*)(void*, CallbackFunc*, InitArgs...), InitArgs...>
+    aw(fn, std::forward<InitArgs>(args)...);
+    return aw;
+  }(std::type_identity<typename callback_signature::arg_tuple>{}, async_func,
+           std::forward<InitArgs>(async_init_args)...);
+}
+
+// TODO implement tmc::detail::awaitable_traits


### PR DESCRIPTION
A utility to make an awaitable from a C-style async function that accepts a callback parameter. This would go in the main library, but there's no guarantee that all of these functions would take parameters (void* user_data, Callback*, InitArgs...) in that order. Some of them may require other parameters beforehand and this would need to be adjusted for that library.

So this is provided as an example instead, which can be used as the foundation to build future integrations.