### PR TITLE
Rename each() to result_each()

### DIFF
--- a/examples/asio/cancellation.cpp
+++ b/examples/asio/cancellation.cpp
@@ -1,7 +1,7 @@
-// Demonstrate how to use tmc::spawn_tuple().each() to await heterogeneous
-// operations that complete at different times. By submitting a long-running
-// operation and a short running timer, timeout-based cancellation can be
-// achieved.
+// Demonstrate how to use tmc::spawn_tuple().result_each() to await
+// heterogeneous operations that complete at different times. By submitting a
+// long-running operation and a short running timer, timeout-based cancellation
+// can be achieved.
 
 // The timeout nominally occurs after 100ms and the timestamps of the various
 // events are logged. Note that the this example signals the cancellation event
@@ -14,8 +14,8 @@
 // Note: Asio already exposes timeout functions for some operations which are
 // probably easier/more performant when available. Alternatively, you could
 // cancel the main operation directly from within the timeout operation. This
-// example serves to also demonstrate how to use the each() function when you
-// need the awaiting thread involved in the process.
+// example serves to also demonstrate how to use the result_each() function when
+// you need the awaiting thread involved in the process.
 #ifdef _WIN32
 #include <SDKDDKVer.h>
 #endif
@@ -85,14 +85,14 @@ int main() {
         co_return std::chrono::high_resolution_clock::now();
       }();
 
-      // Using the each() customizer allows us to receive each result
+      // Using the result_each() customizer allows us to receive each result
       // immediately as it becomes ready, even if the other tasks are still
       // running
       auto eachResult =
         tmc::spawn_tuple(
           mainOperationHandle.async_wait(tmc::aw_asio), std::move(timeoutTask)
         )
-          .each();
+          .result_each();
 
       for (auto readyIdx = co_await eachResult; readyIdx != eachResult.end();
            readyIdx = co_await eachResult) {

--- a/tests/test_spawn_func_many_each.ipp
+++ b/tests/test_spawn_func_many_each.ipp
@@ -15,7 +15,7 @@ template <int N> tmc::task<void> spawn_func_many_each_static_sized_iterator() {
   // Provide the template parameter N to spawn_func_many, so that tasks and
   // results can be statically allocated in std::array.
   std::array<int, N> results;
-  auto ts = tmc::spawn_func_many<N>(iter.begin()).each();
+  auto ts = tmc::spawn_func_many<N>(iter.begin()).result_each();
   for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
     results[idx] = ts[idx];
   }
@@ -45,7 +45,7 @@ tmc::task<void> spawn_func_many_each_static_bounded_iterator() {
                   return t;
                 });
     std::array<int, N> results;
-    auto ts = tmc::spawn_func_many<N>(iter.begin(), iter.end()).each();
+    auto ts = tmc::spawn_func_many<N>(iter.begin(), iter.end()).result_each();
     for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
       results[idx] = ts[idx];
     }
@@ -71,7 +71,7 @@ tmc::task<void> spawn_func_many_each_static_bounded_iterator() {
                 });
 
     std::array<int, N> results;
-    auto ts = tmc::spawn_func_many<N>(iter.begin(), iter.end()).each();
+    auto ts = tmc::spawn_func_many<N>(iter.begin(), iter.end()).result_each();
     for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
       results[idx] = ts[idx];
     }
@@ -93,7 +93,7 @@ tmc::task<void> spawn_func_many_each_dynamic_known_sized_iterator() {
   // This overload will produce a right-sized output vector
   // (internally calculated from tasks.end() - tasks.begin())
   std::vector<int> results;
-  auto ts = tmc::spawn_func_many(iter.begin(), iter.end()).each();
+  auto ts = tmc::spawn_func_many(iter.begin(), iter.end()).result_each();
   for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
     results.push_back(ts[idx]);
   }
@@ -124,7 +124,7 @@ tmc::task<void> spawn_func_many_each_dynamic_unknown_sized_iterator() {
   // reallocating as needed), and after the number of tasks has been determined,
   // a right-sized result vector will be constructed.
   std::vector<int> results;
-  auto ts = tmc::spawn_func_many(iter.begin(), iter.end()).each();
+  auto ts = tmc::spawn_func_many(iter.begin(), iter.end()).result_each();
   for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
     results.push_back(ts[idx]);
   }
@@ -153,7 +153,8 @@ tmc::task<void> spawn_func_many_each_dynamic_bounded_iterator() {
                   return t;
                 });
     std::vector<int> results;
-    auto ts = tmc::spawn_func_many(iter.begin(), iter.end(), MaxTasks).each();
+    auto ts =
+      tmc::spawn_func_many(iter.begin(), iter.end(), MaxTasks).result_each();
     for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
       results.push_back(ts[idx]);
     }
@@ -178,7 +179,8 @@ tmc::task<void> spawn_func_many_each_dynamic_bounded_iterator() {
                   return t;
                 });
     std::vector<int> results;
-    auto ts = tmc::spawn_func_many(iter.begin(), iter.end(), MaxTasks).each();
+    auto ts =
+      tmc::spawn_func_many(iter.begin(), iter.end(), MaxTasks).result_each();
     for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
       results.push_back(ts[idx]);
     }

--- a/tests/test_spawn_many_each.ipp
+++ b/tests/test_spawn_many_each.ipp
@@ -15,7 +15,7 @@ template <int N> tmc::task<void> spawn_many_each_static_sized_iterator() {
   // Provide the template parameter N to spawn_many, so that tasks and results
   // can be statically allocated in std::array.
   std::array<int, N> results;
-  auto ts = tmc::spawn_many<N>(iter.begin()).each();
+  auto ts = tmc::spawn_many<N>(iter.begin()).result_each();
   for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
     results[idx] = ts[idx];
   }
@@ -46,7 +46,7 @@ template <int N> tmc::task<void> spawn_many_each_static_bounded_iterator() {
                   return t;
                 });
     std::array<int, N> results;
-    auto ts = tmc::spawn_many<N>(iter.begin(), iter.end()).each();
+    auto ts = tmc::spawn_many<N>(iter.begin(), iter.end()).result_each();
     for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
       results[idx] = ts[idx];
     }
@@ -72,7 +72,7 @@ template <int N> tmc::task<void> spawn_many_each_static_bounded_iterator() {
                 });
 
     std::array<int, N> results;
-    auto ts = tmc::spawn_many<N>(iter.begin(), iter.end()).each();
+    auto ts = tmc::spawn_many<N>(iter.begin(), iter.end()).result_each();
     for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
       results[idx] = ts[idx];
     }
@@ -95,7 +95,7 @@ tmc::task<void> spawn_many_each_dynamic_known_sized_iterator() {
   // This overload will produce a right-sized output vector
   // (internally calculated from tasks.end() - tasks.begin())
   std::vector<int> results;
-  auto ts = tmc::spawn_many(iter.begin(), iter.end()).each();
+  auto ts = tmc::spawn_many(iter.begin(), iter.end()).result_each();
   for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
     results.push_back(ts[idx]);
   }
@@ -128,7 +128,7 @@ tmc::task<void> spawn_many_each_dynamic_unknown_sized_iterator() {
   // reallocating as needed), and after the number of tasks has been determined,
   // a right-sized result vector will be constructed.
   std::vector<int> results;
-  auto ts = tmc::spawn_many(iter.begin(), iter.end()).each();
+  auto ts = tmc::spawn_many(iter.begin(), iter.end()).result_each();
   for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
     results.push_back(ts[idx]);
   }
@@ -158,7 +158,7 @@ template <int N> tmc::task<void> spawn_many_each_dynamic_bounded_iterator() {
                   return t;
                 });
     std::vector<int> results;
-    auto ts = tmc::spawn_many(iter.begin(), iter.end(), MaxTasks).each();
+    auto ts = tmc::spawn_many(iter.begin(), iter.end(), MaxTasks).result_each();
     for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
       results.push_back(ts[idx]);
     }
@@ -183,7 +183,7 @@ template <int N> tmc::task<void> spawn_many_each_dynamic_bounded_iterator() {
                   return t;
                 });
     std::vector<int> results;
-    auto ts = tmc::spawn_many(iter.begin(), iter.end(), MaxTasks).each();
+    auto ts = tmc::spawn_many(iter.begin(), iter.end(), MaxTasks).result_each();
     for (auto idx = co_await ts; idx != ts.end(); idx = co_await ts) {
       results.push_back(ts[idx]);
     }

--- a/tests/test_spawn_tuple.ipp
+++ b/tests/test_spawn_tuple.ipp
@@ -74,9 +74,9 @@ static inline tmc::task<void> spawn_tuple_task_fork() {
   EXPECT_EQ(sum, (1 << 3) - 1);
 }
 
-static inline tmc::task<void> spawn_tuple_task_each() {
+static inline tmc::task<void> spawn_tuple_task_result_each() {
   auto ts = tmc::spawn_tuple(work(0), work(1), work(2));
-  auto each = std::move(ts).each();
+  auto each = std::move(ts).result_each();
 
   int sum = 0;
   for (size_t i = co_await each; i != each.end(); i = co_await each) {
@@ -125,6 +125,6 @@ TEST_F(CATEGORY, spawn_tuple_task_fork) {
 
 TEST_F(CATEGORY, spawn_tuple_task_each) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    co_await spawn_tuple_task_each();
+    co_await spawn_tuple_task_result_each();
   }());
 }


### PR DESCRIPTION
The result_ prefix now indicates any awaitable customization that modifies the structure of the returned results. The next planned implementation is result_channel() which will return the results one-by-one as they become ready.