### PR TITLE
Additional test coverage

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,7 +38,11 @@ make_exe(
   tests
   main.cpp
   assert_ex_cpu.cpp
+  assert_coro.cpp
   assert_spawn.cpp
+  assert_spawn_func.cpp
+  assert_spawn_many.cpp
+  assert_spawn_tuple.cpp
   test_ex_cpu.cpp
   test_ex_asio.cpp
   test_ex_braid.cpp

--- a/tests/assert_coro.cpp
+++ b/tests/assert_coro.cpp
@@ -1,0 +1,40 @@
+#include "test_common.hpp"
+
+#include <gtest/gtest.h>
+
+#define CATEGORY assert_coro_DeathTest
+
+#ifndef NDEBUG
+
+TEST(CATEGORY, none) {
+  EXPECT_DEATH(
+    {
+      tmc::ex_cpu ex;
+      ex.set_thread_count(1).set_priority_count(1).init();
+      test_async_main(ex, []() -> tmc::task<void> {
+        auto x = []() -> tmc::task<void> { co_return; }();
+        co_return;
+      }());
+    },
+    "co_await"
+  );
+}
+
+TEST(CATEGORY, co_await_twice) {
+  EXPECT_DEATH(
+    {
+      tmc::ex_cpu ex;
+      ex.set_thread_count(1).set_priority_count(1).init();
+      test_async_main(ex, []() -> tmc::task<void> {
+        auto x = []() -> tmc::task<void> { co_return; }();
+        co_await std::move(x);
+        co_await std::move(x);
+      }());
+    },
+    "once"
+  );
+}
+
+#endif
+
+#undef CATEGORY

--- a/tests/assert_spawn_func.cpp
+++ b/tests/assert_spawn_func.cpp
@@ -2,7 +2,7 @@
 
 #include <gtest/gtest.h>
 
-#define CATEGORY assert_spawn_DeathTest
+#define CATEGORY assert_spawn_func_DeathTest
 
 #ifndef NDEBUG
 
@@ -12,7 +12,7 @@ TEST(CATEGORY, none) {
       tmc::ex_cpu ex;
       ex.set_thread_count(1).set_priority_count(1).init();
       test_async_main(ex, []() -> tmc::task<void> {
-        auto x = tmc::spawn([]() -> tmc::task<void> { co_return; }());
+        auto x = tmc::spawn_func([]() -> void {});
         co_return;
       }());
     },
@@ -26,7 +26,7 @@ TEST(CATEGORY, fork_none) {
       tmc::ex_cpu ex;
       ex.set_thread_count(1).set_priority_count(1).init();
       test_async_main(ex, []() -> tmc::task<void> {
-        auto x = tmc::spawn([]() -> tmc::task<void> { co_return; }()).fork();
+        auto x = tmc::spawn_func([]() -> void {}).fork();
         co_return;
       }());
     },
@@ -40,7 +40,7 @@ TEST(CATEGORY, co_await_twice) {
       tmc::ex_cpu ex;
       ex.set_thread_count(1).set_priority_count(1).init();
       test_async_main(ex, []() -> tmc::task<void> {
-        auto x = tmc::spawn([]() -> tmc::task<void> { co_return; }());
+        auto x = tmc::spawn_func([]() -> void {});
         co_await std::move(x);
         co_await std::move(x);
         co_return;
@@ -56,7 +56,7 @@ TEST(CATEGORY, fork_co_await_twice) {
       tmc::ex_cpu ex;
       ex.set_thread_count(1).set_priority_count(1).init();
       test_async_main(ex, []() -> tmc::task<void> {
-        auto x = tmc::spawn([]() -> tmc::task<void> { co_return; }()).fork();
+        auto x = tmc::spawn_func([]() -> void {}).fork();
         co_await std::move(x);
         co_await std::move(x);
         co_return;
@@ -72,7 +72,7 @@ TEST(CATEGORY, fork_twice) {
       tmc::ex_cpu ex;
       ex.set_thread_count(1).set_priority_count(1).init();
       test_async_main(ex, []() -> tmc::task<void> {
-        auto x = tmc::spawn([]() -> tmc::task<void> { co_return; }());
+        auto x = tmc::spawn_func([]() -> void {});
         auto y = std::move(x).fork();
         auto z = std::move(x).fork();
         co_return;
@@ -88,7 +88,7 @@ TEST(CATEGORY, detach_twice) {
       tmc::ex_cpu ex;
       ex.set_thread_count(1).set_priority_count(1).init();
       test_async_main(ex, []() -> tmc::task<void> {
-        auto x = tmc::spawn([]() -> tmc::task<void> { co_return; }());
+        auto x = tmc::spawn_func([]() -> void {});
         std::move(x).detach();
         std::move(x).detach();
         co_return;

--- a/tests/assert_spawn_tuple.cpp
+++ b/tests/assert_spawn_tuple.cpp
@@ -2,7 +2,7 @@
 
 #include <gtest/gtest.h>
 
-#define CATEGORY assert_spawn_DeathTest
+#define CATEGORY assert_spawn_tuple_DeathTest
 
 #ifndef NDEBUG
 
@@ -12,7 +12,7 @@ TEST(CATEGORY, none) {
       tmc::ex_cpu ex;
       ex.set_thread_count(1).set_priority_count(1).init();
       test_async_main(ex, []() -> tmc::task<void> {
-        auto x = tmc::spawn([]() -> tmc::task<void> { co_return; }());
+        auto x = tmc::spawn_tuple([]() -> tmc::task<void> { co_return; }());
         co_return;
       }());
     },
@@ -26,7 +26,23 @@ TEST(CATEGORY, fork_none) {
       tmc::ex_cpu ex;
       ex.set_thread_count(1).set_priority_count(1).init();
       test_async_main(ex, []() -> tmc::task<void> {
-        auto x = tmc::spawn([]() -> tmc::task<void> { co_return; }()).fork();
+        auto x =
+          tmc::spawn_tuple([]() -> tmc::task<void> { co_return; }()).fork();
+        co_return;
+      }());
+    },
+    "co_await"
+  );
+}
+
+TEST(CATEGORY, each_none) {
+  EXPECT_DEATH(
+    {
+      tmc::ex_cpu ex;
+      ex.set_thread_count(1).set_priority_count(1).init();
+      test_async_main(ex, []() -> tmc::task<void> {
+        auto x = tmc::spawn_tuple([]() -> tmc::task<void> { co_return; }())
+                   .result_each();
         co_return;
       }());
     },
@@ -40,7 +56,7 @@ TEST(CATEGORY, co_await_twice) {
       tmc::ex_cpu ex;
       ex.set_thread_count(1).set_priority_count(1).init();
       test_async_main(ex, []() -> tmc::task<void> {
-        auto x = tmc::spawn([]() -> tmc::task<void> { co_return; }());
+        auto x = tmc::spawn_tuple([]() -> tmc::task<void> { co_return; }());
         co_await std::move(x);
         co_await std::move(x);
         co_return;
@@ -56,7 +72,8 @@ TEST(CATEGORY, fork_co_await_twice) {
       tmc::ex_cpu ex;
       ex.set_thread_count(1).set_priority_count(1).init();
       test_async_main(ex, []() -> tmc::task<void> {
-        auto x = tmc::spawn([]() -> tmc::task<void> { co_return; }()).fork();
+        auto x =
+          tmc::spawn_tuple([]() -> tmc::task<void> { co_return; }()).fork();
         co_await std::move(x);
         co_await std::move(x);
         co_return;
@@ -72,7 +89,7 @@ TEST(CATEGORY, fork_twice) {
       tmc::ex_cpu ex;
       ex.set_thread_count(1).set_priority_count(1).init();
       test_async_main(ex, []() -> tmc::task<void> {
-        auto x = tmc::spawn([]() -> tmc::task<void> { co_return; }());
+        auto x = tmc::spawn_tuple([]() -> tmc::task<void> { co_return; }());
         auto y = std::move(x).fork();
         auto z = std::move(x).fork();
         co_return;
@@ -88,9 +105,25 @@ TEST(CATEGORY, detach_twice) {
       tmc::ex_cpu ex;
       ex.set_thread_count(1).set_priority_count(1).init();
       test_async_main(ex, []() -> tmc::task<void> {
-        auto x = tmc::spawn([]() -> tmc::task<void> { co_return; }());
-        std::move(x).detach();
-        std::move(x).detach();
+        auto x = tmc::spawn_tuple([]() -> tmc::task<void> { co_return; }());
+        x.detach();
+        x.detach();
+        co_return;
+      }());
+    },
+    "once"
+  );
+}
+
+TEST(CATEGORY, each_twice) {
+  EXPECT_DEATH(
+    {
+      tmc::ex_cpu ex;
+      ex.set_thread_count(1).set_priority_count(1).init();
+      test_async_main(ex, []() -> tmc::task<void> {
+        auto x = tmc::spawn_tuple([]() -> tmc::task<void> { co_return; }());
+        auto y = std::move(x).result_each();
+        auto z = std::move(x).result_each();
         co_return;
       }());
     },

--- a/tests/test_channel.cpp
+++ b/tests/test_channel.cpp
@@ -133,29 +133,6 @@ TEST_F(CATEGORY, push_single_threaded) {
   }());
 }
 
-struct destructor_counter {
-  std::atomic<size_t>* count;
-  destructor_counter(std::atomic<size_t>* C) noexcept : count{C} {}
-  destructor_counter(destructor_counter const& Other) = delete;
-  destructor_counter& operator=(destructor_counter const& Other) = delete;
-
-  destructor_counter(destructor_counter&& Other) noexcept {
-    count = Other.count;
-    Other.count = nullptr;
-  }
-  destructor_counter& operator=(destructor_counter&& Other) noexcept {
-    count = Other.count;
-    Other.count = nullptr;
-    return *this;
-  }
-
-  ~destructor_counter() {
-    if (count != nullptr) {
-      ++(*count);
-    }
-  }
-};
-
 TEST_F(CATEGORY, destroy_chan_with_data) {
   test_async_main(ex(), []() -> tmc::task<void> {
     std::atomic<size_t> count;

--- a/tests/test_common.hpp
+++ b/tests/test_common.hpp
@@ -34,6 +34,29 @@ template <typename Arr> tmc::task<size_t> inc_task_int(Arr& arr, size_t idx) {
   co_return idx;
 };
 
+struct destructor_counter {
+  std::atomic<size_t>* count;
+  destructor_counter(std::atomic<size_t>* C) noexcept : count{C} {}
+  destructor_counter(destructor_counter const& Other) = delete;
+  destructor_counter& operator=(destructor_counter const& Other) = delete;
+
+  destructor_counter(destructor_counter&& Other) noexcept {
+    count = Other.count;
+    Other.count = nullptr;
+  }
+  destructor_counter& operator=(destructor_counter&& Other) noexcept {
+    count = Other.count;
+    Other.count = nullptr;
+    return *this;
+  }
+
+  ~destructor_counter() {
+    if (count != nullptr) {
+      ++(*count);
+    }
+  }
+};
+
 // test_async_main_int is similar to tmc::async_main
 // it returns an int value to be used as an "exit code"
 template <typename Executor>

--- a/tests/test_ex_asio.cpp
+++ b/tests/test_ex_asio.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+
 #define CATEGORY test_ex_asio
 
 class CATEGORY : public testing::Test {
@@ -12,6 +14,37 @@ protected:
 
   static tmc::ex_asio& ex() { return tmc::asio_executor(); }
 };
+
+TEST_F(CATEGORY, set_thread_init_hook) {
+  tmc::ex_asio ex;
+  std::atomic<size_t> thr = TMC_ALL_ONES;
+  ex.set_thread_init_hook([&](size_t tid) -> void { thr = tid; }).init();
+}
+
+TEST_F(CATEGORY, set_thread_teardown_hook) {
+  tmc::ex_asio ex;
+  std::atomic<size_t> thr = TMC_ALL_ONES;
+  ex.set_thread_teardown_hook([&](size_t tid) -> void { thr = tid; }).init();
+}
+
+TEST_F(CATEGORY, no_init) { tmc::ex_asio ex; }
+
+TEST_F(CATEGORY, init_twice) {
+  tmc::ex_asio ex;
+  ex.init();
+  ex.init();
+}
+
+TEST_F(CATEGORY, teardown_twice) {
+  tmc::ex_asio ex;
+  ex.teardown();
+  ex.teardown();
+}
+
+TEST_F(CATEGORY, teardown_and_destroy) {
+  tmc::ex_asio ex;
+  ex.teardown();
+}
 
 #include "test_executors.ipp"
 #include "test_nested_executors.ipp"

--- a/tests/test_ex_cpu.cpp
+++ b/tests/test_ex_cpu.cpp
@@ -40,11 +40,6 @@ TEST_F(CATEGORY, set_thread_count) {
   EXPECT_EQ(ex.thread_count(), 1);
 }
 
-TEST_F(CATEGORY, set_thread_occupancy) {
-  tmc::ex_cpu ex;
-  ex.set_thread_occupancy(1.0f).init();
-}
-
 TEST_F(CATEGORY, set_thread_init_hook) {
   tmc::ex_cpu ex;
   std::atomic<size_t> thr = TMC_ALL_ONES;
@@ -56,6 +51,13 @@ TEST_F(CATEGORY, set_thread_teardown_hook) {
   std::atomic<size_t> thr = TMC_ALL_ONES;
   ex.set_thread_teardown_hook([&](size_t tid) -> void { thr = tid; }).init();
 }
+
+#ifdef TMC_USE_HWLOC
+TEST_F(CATEGORY, set_thread_occupancy) {
+  tmc::ex_cpu ex;
+  ex.set_thread_occupancy(1.0f).init();
+}
+#endif
 
 TEST_F(CATEGORY, no_init) { tmc::ex_cpu ex; }
 

--- a/tests/test_ex_cpu.cpp
+++ b/tests/test_ex_cpu.cpp
@@ -3,6 +3,8 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+
 #define CATEGORY test_ex_cpu
 
 class CATEGORY : public testing::Test {
@@ -25,6 +27,53 @@ TEST_F(CATEGORY, clamp_priority) {
     1
   )
     .wait();
+}
+
+TEST_F(CATEGORY, set_prio) {
+  tmc::ex_cpu ex;
+  ex.set_priority_count(1).init();
+}
+
+TEST_F(CATEGORY, set_thread_count) {
+  tmc::ex_cpu ex;
+  ex.set_thread_count(1).init();
+  EXPECT_EQ(ex.thread_count(), 1);
+}
+
+TEST_F(CATEGORY, set_thread_occupancy) {
+  tmc::ex_cpu ex;
+  ex.set_thread_occupancy(1.0f).init();
+}
+
+TEST_F(CATEGORY, set_thread_init_hook) {
+  tmc::ex_cpu ex;
+  std::atomic<size_t> thr = TMC_ALL_ONES;
+  ex.set_thread_init_hook([&](size_t tid) -> void { thr = tid; }).init();
+}
+
+TEST_F(CATEGORY, set_thread_teardown_hook) {
+  tmc::ex_cpu ex;
+  std::atomic<size_t> thr = TMC_ALL_ONES;
+  ex.set_thread_teardown_hook([&](size_t tid) -> void { thr = tid; }).init();
+}
+
+TEST_F(CATEGORY, no_init) { tmc::ex_cpu ex; }
+
+TEST_F(CATEGORY, init_twice) {
+  tmc::ex_cpu ex;
+  ex.init();
+  ex.init();
+}
+
+TEST_F(CATEGORY, teardown_twice) {
+  tmc::ex_cpu ex;
+  ex.teardown();
+  ex.teardown();
+}
+
+TEST_F(CATEGORY, teardown_and_destroy) {
+  tmc::ex_cpu ex;
+  ex.teardown();
 }
 
 #include "test_executors.ipp"

--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -61,11 +61,15 @@ TEST_F(CATEGORY, qu_inbox_try_push_full) {
   test_async_main(ex(), []() -> tmc::task<void> {
     atomic_awaitable<int> aa(0, 32000);
     for (size_t i = 0; i < 32000; ++i) {
-      tmc::post(ex(), [](atomic_awaitable<int>& AA) -> tmc::task<void> {
-        ++AA.ref();
-        AA.ref().notify_all();
-        co_return;
-      }(aa));
+      tmc::post(
+        ex(),
+        [](atomic_awaitable<int>& AA) -> tmc::task<void> {
+          ++AA.ref();
+          AA.ref().notify_all();
+          co_return;
+        }(aa),
+        0, 0
+      );
     }
     co_await aa;
   }());

--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -8,6 +8,8 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
+
 #define CATEGORY test_misc
 
 class CATEGORY : public testing::Test {
@@ -112,6 +114,17 @@ TEST_F(CATEGORY, post_bulk_checked_default_executor) {
   }());
 
   tmc::set_default_executor(nullptr);
+}
+
+TEST_F(CATEGORY, tiny_vec_resize_zero) {
+
+  std::atomic<size_t> count;
+  tmc::detail::tiny_vec<destructor_counter> tv;
+  tv.resize(2);
+  tv.emplace_at(0, &count);
+  tv.emplace_at(1, &count);
+  tv.resize(0);
+  EXPECT_EQ(count.load(), 2);
 }
 
 #undef CATEGORY

--- a/tests/test_nested_executors.ipp
+++ b/tests/test_nested_executors.ipp
@@ -183,7 +183,7 @@ TEST_F(CATEGORY, test_spawn_func_fork_run_resume) {
 
     EXPECT_EQ(tmc::detail::this_thread::executor, ex().type_erased());
 
-    auto t2 = tmc::spawn_func([]() -> void {}).resume_on(localEx);
+    auto t2 = tmc::spawn_func([]() -> void {}).resume_on(localEx).fork();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     EXPECT_EQ(tmc::detail::this_thread::executor, ex().type_erased());
     co_await std::move(t2);
@@ -278,7 +278,7 @@ TEST_F(CATEGORY, test_spawn_many_fork_run_resume) {
       co_return;
     }(localEx.type_erased());
 
-    auto t1 = tmc::spawn_many(tasks).run_on(localEx);
+    auto t1 = tmc::spawn_many(tasks).run_on(localEx).fork();
 
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
 
@@ -287,7 +287,7 @@ TEST_F(CATEGORY, test_spawn_many_fork_run_resume) {
     EXPECT_EQ(tmc::detail::this_thread::executor, ex().type_erased());
 
     tasks[0] = []() -> tmc::task<void> { co_return; }();
-    auto t2 = tmc::spawn_many(tasks).resume_on(localEx);
+    auto t2 = tmc::spawn_many(tasks).resume_on(localEx).fork();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     EXPECT_EQ(tmc::detail::this_thread::executor, ex().type_erased());
     co_await std::move(t2);

--- a/tests/test_nested_executors.ipp
+++ b/tests/test_nested_executors.ipp
@@ -9,6 +9,9 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <thread>
+
 // All 3 of the tests in this file produce TSan false positives in the same way:
 // 1. Inner coro enter()s the nested executor (this is the "racing read" to
 // TSan)
@@ -114,6 +117,36 @@ TEST_F(CATEGORY, test_spawn_run_resume) {
   }());
 }
 
+TEST_F(CATEGORY, test_spawn_fork_run_resume) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    tmc::ex_cpu localEx;
+    localEx.set_thread_count(1).init();
+
+    auto t1 = tmc::spawn([](tmc::ex_any* Ex) -> tmc::task<void> {
+                EXPECT_EQ(tmc::detail::this_thread::executor, Ex);
+                co_return;
+              }(localEx.type_erased()))
+                .run_on(localEx)
+                .fork();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    co_await std::move(t1);
+
+    EXPECT_EQ(tmc::detail::this_thread::executor, ex().type_erased());
+
+    auto t2 = tmc::spawn([]() -> tmc::task<void> { co_return; }())
+                .resume_on(localEx)
+                .fork();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    EXPECT_EQ(tmc::detail::this_thread::executor, ex().type_erased());
+    co_await std::move(t2);
+    EXPECT_EQ(tmc::detail::this_thread::executor, localEx.type_erased());
+
+    co_await tmc::resume_on(ex());
+  }());
+}
+
 TEST_F(CATEGORY, test_spawn_func_run_resume) {
   test_async_main(ex(), []() -> tmc::task<void> {
     tmc::ex_cpu localEx;
@@ -126,6 +159,34 @@ TEST_F(CATEGORY, test_spawn_func_run_resume) {
     EXPECT_EQ(tmc::detail::this_thread::executor, ex().type_erased());
 
     co_await tmc::spawn_func([]() -> void {}).resume_on(localEx);
+    EXPECT_EQ(tmc::detail::this_thread::executor, localEx.type_erased());
+
+    co_await tmc::resume_on(ex());
+  }());
+}
+
+TEST_F(CATEGORY, test_spawn_func_fork_run_resume) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    tmc::ex_cpu localEx;
+    localEx.set_thread_count(1).init();
+
+    auto t1 =
+      tmc::spawn_func([&]() -> void {
+        EXPECT_EQ(tmc::detail::this_thread::executor, localEx.type_erased());
+      })
+        .run_on(localEx)
+        .fork();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    co_await std::move(t1);
+
+    EXPECT_EQ(tmc::detail::this_thread::executor, ex().type_erased());
+
+    auto t2 = tmc::spawn_func([]() -> void {}).resume_on(localEx);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    EXPECT_EQ(tmc::detail::this_thread::executor, ex().type_erased());
+    co_await std::move(t2);
     EXPECT_EQ(tmc::detail::this_thread::executor, localEx.type_erased());
 
     co_await tmc::resume_on(ex());
@@ -153,6 +214,36 @@ TEST_F(CATEGORY, test_spawn_tuple_run_resume) {
   }());
 }
 
+TEST_F(CATEGORY, test_spawn_tuple_fork_run_resume) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    tmc::ex_cpu localEx;
+    localEx.set_thread_count(1).init();
+
+    auto t1 = tmc::spawn_tuple([](tmc::ex_any* Ex) -> tmc::task<void> {
+                EXPECT_EQ(tmc::detail::this_thread::executor, Ex);
+                co_return;
+              }(localEx.type_erased()))
+                .run_on(localEx)
+                .fork();
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    co_await std::move(t1);
+
+    EXPECT_EQ(tmc::detail::this_thread::executor, ex().type_erased());
+
+    auto t2 = tmc::spawn_tuple([]() -> tmc::task<void> { co_return; }())
+                .resume_on(localEx)
+                .fork();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    EXPECT_EQ(tmc::detail::this_thread::executor, ex().type_erased());
+    co_await std::move(t2);
+    EXPECT_EQ(tmc::detail::this_thread::executor, localEx.type_erased());
+
+    co_await tmc::resume_on(ex());
+  }());
+}
+
 TEST_F(CATEGORY, test_spawn_many_run_resume) {
   test_async_main(ex(), []() -> tmc::task<void> {
     tmc::ex_cpu localEx;
@@ -170,6 +261,36 @@ TEST_F(CATEGORY, test_spawn_many_run_resume) {
 
     tasks[0] = []() -> tmc::task<void> { co_return; }();
     co_await tmc::spawn_many(tasks).resume_on(localEx);
+    EXPECT_EQ(tmc::detail::this_thread::executor, localEx.type_erased());
+
+    co_await tmc::resume_on(ex());
+  }());
+}
+
+TEST_F(CATEGORY, test_spawn_many_fork_run_resume) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    tmc::ex_cpu localEx;
+    localEx.set_thread_count(1).init();
+
+    std::array<tmc::task<void>, 1> tasks;
+    tasks[0] = [](tmc::ex_any* Ex) -> tmc::task<void> {
+      EXPECT_EQ(tmc::detail::this_thread::executor, Ex);
+      co_return;
+    }(localEx.type_erased());
+
+    auto t1 = tmc::spawn_many(tasks).run_on(localEx);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+    co_await std::move(t1);
+
+    EXPECT_EQ(tmc::detail::this_thread::executor, ex().type_erased());
+
+    tasks[0] = []() -> tmc::task<void> { co_return; }();
+    auto t2 = tmc::spawn_many(tasks).resume_on(localEx);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    EXPECT_EQ(tmc::detail::this_thread::executor, ex().type_erased());
+    co_await std::move(t2);
     EXPECT_EQ(tmc::detail::this_thread::executor, localEx.type_erased());
 
     co_await tmc::resume_on(ex());

--- a/tests/test_spawn_tuple.ipp
+++ b/tests/test_spawn_tuple.ipp
@@ -9,6 +9,12 @@
 
 // tests ported from examples/spawn_iterator.cpp
 
+TEST_F(CATEGORY, spawn_tuple_empty) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    std::tuple<> results = co_await tmc::spawn_tuple();
+  }());
+}
+
 TEST_F(CATEGORY, spawn_tuple_task_func) {
   test_async_main(ex(), []() -> tmc::task<void> {
     std::tuple<int, int, int> results =

--- a/tests/test_spawn_tuple.ipp
+++ b/tests/test_spawn_tuple.ipp
@@ -9,122 +9,111 @@
 
 // tests ported from examples/spawn_iterator.cpp
 
-static inline tmc::task<void> spawn_tuple_task_func() {
-
-  std::tuple<int, int, int> results =
-    co_await tmc::spawn_tuple(work(0), work(1), work(2));
-
-  [[maybe_unused]] auto sum =
-    std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
-
-  EXPECT_EQ(sum, (1 << 3) - 1);
-}
-
-static inline tmc::task<void> spawn_tuple_task_lambda() {
-  {
-    // non-capturing lambda coroutine
-    auto f = [](int i) -> tmc::task<int> { co_return 1 << i; };
-    std::tuple<int, int, int> results =
-      co_await tmc::spawn_tuple(f(0), f(1), f(2));
-
-    [[maybe_unused]] auto sum =
-      std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
-
-    EXPECT_EQ(sum, (1 << 3) - 1);
-  }
-  {
-    // capturing lambda that forwards to non-capturing lambda coroutine
-    int i = 0;
-    auto f = [&i]() -> tmc::task<int> {
-      return [](int j) -> tmc::task<int> { co_return 1 << j; }(i++);
-    };
-    std::tuple<int, int, int> results =
-      co_await tmc::spawn_tuple(f(), f(), f());
-
-    [[maybe_unused]] auto sum =
-      std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
-
-    EXPECT_EQ(sum, (1 << 3) - 1);
-  }
-}
-
-static inline tmc::task<void> spawn_tuple_task_tuple() {
-  std::tuple<tmc::task<int>, tmc::task<int>, tmc::task<int>> tasks{
-    work(0), work(1), work(2)
-  };
-
-  std::tuple<int, int, int> results =
-    co_await tmc::spawn_tuple(std::move(tasks));
-
-  [[maybe_unused]] auto sum =
-    std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
-
-  EXPECT_EQ(sum, (1 << 3) - 1);
-}
-
-static inline tmc::task<void> spawn_tuple_task_fork() {
-  auto ts = tmc::spawn_tuple(work(0), work(1), work(2));
-  auto early = std::move(ts).fork();
-
-  std::tuple<int, int, int> results = co_await std::move(early);
-
-  [[maybe_unused]] auto sum =
-    std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
-
-  EXPECT_EQ(sum, (1 << 3) - 1);
-}
-
-static inline tmc::task<void> spawn_tuple_task_result_each() {
-  auto ts = tmc::spawn_tuple(work(0), work(1), work(2));
-  auto each = std::move(ts).result_each();
-
-  int sum = 0;
-  for (size_t i = co_await each; i != each.end(); i = co_await each) {
-    switch (i) {
-    case 0:
-      sum += each.get<0>();
-      break;
-    case 1:
-      sum += each.get<1>();
-      break;
-    case 2:
-      sum += each.get<2>();
-      break;
-    default:
-      ADD_FAILURE() << "invalid index: " << i;
-      break;
-    }
-  }
-
-  EXPECT_EQ(sum, (1 << 3) - 1);
-}
-
 TEST_F(CATEGORY, spawn_tuple_task_func) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    co_await spawn_tuple_task_func();
+    co_await []() -> tmc::task<void> {
+      std::tuple<int, int, int> results =
+        co_await tmc::spawn_tuple(work(0), work(1), work(2));
+
+      [[maybe_unused]] auto sum =
+        std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
+
+      EXPECT_EQ(sum, (1 << 3) - 1);
+    }();
   }());
 }
 
 TEST_F(CATEGORY, spawn_tuple_task_lambda) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    co_await spawn_tuple_task_func();
+    co_await []() -> tmc::task<void> {
+      {
+        // non-capturing lambda coroutine
+        auto f = [](int i) -> tmc::task<int> { co_return 1 << i; };
+        std::tuple<int, int, int> results =
+          co_await tmc::spawn_tuple(f(0), f(1), f(2));
+
+        [[maybe_unused]] auto sum =
+          std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
+
+        EXPECT_EQ(sum, (1 << 3) - 1);
+      }
+      {
+        // capturing lambda that forwards to non-capturing lambda coroutine
+        int i = 0;
+        auto f = [&i]() -> tmc::task<int> {
+          return [](int j) -> tmc::task<int> { co_return 1 << j; }(i++);
+        };
+        std::tuple<int, int, int> results =
+          co_await tmc::spawn_tuple(f(), f(), f());
+
+        [[maybe_unused]] auto sum =
+          std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
+
+        EXPECT_EQ(sum, (1 << 3) - 1);
+      }
+    }();
   }());
 }
 
 TEST_F(CATEGORY, spawn_tuple_task_tuple) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    co_await spawn_tuple_task_tuple();
+    co_await []() -> tmc::task<void> {
+      std::tuple<tmc::task<int>, tmc::task<int>, tmc::task<int>> tasks{
+        work(0), work(1), work(2)
+      };
+
+      std::tuple<int, int, int> results =
+        co_await tmc::spawn_tuple(std::move(tasks));
+
+      [[maybe_unused]] auto sum =
+        std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
+
+      EXPECT_EQ(sum, (1 << 3) - 1);
+    }();
   }());
 }
 
 TEST_F(CATEGORY, spawn_tuple_task_fork) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    co_await spawn_tuple_task_fork();
+    co_await []() -> tmc::task<void> {
+      auto ts = tmc::spawn_tuple(work(0), work(1), work(2));
+      auto early = std::move(ts).fork();
+
+      std::tuple<int, int, int> results = co_await std::move(early);
+
+      [[maybe_unused]] auto sum =
+        std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
+
+      EXPECT_EQ(sum, (1 << 3) - 1);
+    }();
   }());
 }
 
 TEST_F(CATEGORY, spawn_tuple_task_each) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    co_await spawn_tuple_task_result_each();
+    co_await []() -> tmc::task<void> {
+      auto ts = tmc::spawn_tuple(work(0), work(1), work(2));
+      auto each = std::move(ts).result_each();
+
+      int sum = 0;
+      for (size_t i = co_await each; i != each.end(); i = co_await each) {
+        switch (i) {
+        case 0:
+          sum += each.get<0>();
+          break;
+        case 1:
+          sum += each.get<1>();
+          break;
+        case 2:
+          sum += each.get<2>();
+          break;
+        default:
+          ADD_FAILURE() << "invalid index: " << i;
+          break;
+        }
+      }
+
+      EXPECT_EQ(sum, (1 << 3) - 1);
+    }();
   }());
 }

--- a/tests/test_spawn_tuple.ipp
+++ b/tests/test_spawn_tuple.ipp
@@ -11,109 +11,121 @@
 
 TEST_F(CATEGORY, spawn_tuple_task_func) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    co_await []() -> tmc::task<void> {
-      std::tuple<int, int, int> results =
-        co_await tmc::spawn_tuple(work(0), work(1), work(2));
+    std::tuple<int, int, int> results =
+      co_await tmc::spawn_tuple(work(0), work(1), work(2));
 
-      [[maybe_unused]] auto sum =
-        std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
+    [[maybe_unused]] auto sum =
+      std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
 
-      EXPECT_EQ(sum, (1 << 3) - 1);
-    }();
+    EXPECT_EQ(sum, (1 << 3) - 1);
   }());
 }
 
 TEST_F(CATEGORY, spawn_tuple_task_lambda) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    co_await []() -> tmc::task<void> {
-      {
-        // non-capturing lambda coroutine
-        auto f = [](int i) -> tmc::task<int> { co_return 1 << i; };
-        std::tuple<int, int, int> results =
-          co_await tmc::spawn_tuple(f(0), f(1), f(2));
+    {
+      // non-capturing lambda coroutine
+      auto f = [](int i) -> tmc::task<int> { co_return 1 << i; };
+      std::tuple<int, int, int> results =
+        co_await tmc::spawn_tuple(f(0), f(1), f(2));
 
-        [[maybe_unused]] auto sum =
-          std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
+      [[maybe_unused]] auto sum =
+        std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
 
-        EXPECT_EQ(sum, (1 << 3) - 1);
-      }
-      {
-        // capturing lambda that forwards to non-capturing lambda coroutine
-        int i = 0;
-        auto f = [&i]() -> tmc::task<int> {
-          return [](int j) -> tmc::task<int> { co_return 1 << j; }(i++);
-        };
-        std::tuple<int, int, int> results =
-          co_await tmc::spawn_tuple(f(), f(), f());
+      EXPECT_EQ(sum, (1 << 3) - 1);
+    }
+    {
+      // capturing lambda that forwards to non-capturing lambda coroutine
+      int i = 0;
+      auto f = [&i]() -> tmc::task<int> {
+        return [](int j) -> tmc::task<int> { co_return 1 << j; }(i++);
+      };
+      std::tuple<int, int, int> results =
+        co_await tmc::spawn_tuple(f(), f(), f());
 
-        [[maybe_unused]] auto sum =
-          std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
+      [[maybe_unused]] auto sum =
+        std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
 
-        EXPECT_EQ(sum, (1 << 3) - 1);
-      }
-    }();
+      EXPECT_EQ(sum, (1 << 3) - 1);
+    }
   }());
 }
 
 TEST_F(CATEGORY, spawn_tuple_task_tuple) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    co_await []() -> tmc::task<void> {
-      std::tuple<tmc::task<int>, tmc::task<int>, tmc::task<int>> tasks{
-        work(0), work(1), work(2)
-      };
+    std::tuple<tmc::task<int>, tmc::task<int>, tmc::task<int>> tasks{
+      work(0), work(1), work(2)
+    };
 
-      std::tuple<int, int, int> results =
-        co_await tmc::spawn_tuple(std::move(tasks));
+    std::tuple<int, int, int> results =
+      co_await tmc::spawn_tuple(std::move(tasks));
 
-      [[maybe_unused]] auto sum =
-        std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
+    [[maybe_unused]] auto sum =
+      std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
 
-      EXPECT_EQ(sum, (1 << 3) - 1);
-    }();
+    EXPECT_EQ(sum, (1 << 3) - 1);
   }());
 }
 
 TEST_F(CATEGORY, spawn_tuple_task_fork) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    co_await []() -> tmc::task<void> {
-      auto ts = tmc::spawn_tuple(work(0), work(1), work(2));
-      auto early = std::move(ts).fork();
+    auto ts = tmc::spawn_tuple(work(0), work(1), work(2));
+    auto early = std::move(ts).fork();
 
-      std::tuple<int, int, int> results = co_await std::move(early);
+    std::tuple<int, int, int> results = co_await std::move(early);
 
-      [[maybe_unused]] auto sum =
-        std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
+    [[maybe_unused]] auto sum =
+      std::get<0>(results) + std::get<1>(results) + std::get<2>(results);
 
-      EXPECT_EQ(sum, (1 << 3) - 1);
-    }();
+    EXPECT_EQ(sum, (1 << 3) - 1);
   }());
 }
 
 TEST_F(CATEGORY, spawn_tuple_task_each) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    co_await []() -> tmc::task<void> {
-      auto ts = tmc::spawn_tuple(work(0), work(1), work(2));
-      auto each = std::move(ts).result_each();
+    auto ts = tmc::spawn_tuple(work(0), work(1), work(2));
+    auto each = std::move(ts).result_each();
 
-      int sum = 0;
-      for (size_t i = co_await each; i != each.end(); i = co_await each) {
-        switch (i) {
-        case 0:
-          sum += each.get<0>();
-          break;
-        case 1:
-          sum += each.get<1>();
-          break;
-        case 2:
-          sum += each.get<2>();
-          break;
-        default:
-          ADD_FAILURE() << "invalid index: " << i;
-          break;
-        }
+    int sum = 0;
+    for (size_t i = co_await each; i != each.end(); i = co_await each) {
+      switch (i) {
+      case 0:
+        sum += each.get<0>();
+        break;
+      case 1:
+        sum += each.get<1>();
+        break;
+      case 2:
+        sum += each.get<2>();
+        break;
+      default:
+        ADD_FAILURE() << "invalid index: " << i;
+        break;
       }
+    }
 
-      EXPECT_EQ(sum, (1 << 3) - 1);
-    }();
+    EXPECT_EQ(sum, (1 << 3) - 1);
+  }());
+}
+
+TEST_F(CATEGORY, spawn_tuple_task_detach) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    atomic_awaitable<int> counter(0, 2);
+
+    auto ts = tmc::spawn_tuple(
+      [](std::atomic<int>& Counter) -> tmc::task<void> {
+        ++Counter;
+        Counter.notify_all();
+        co_return;
+      }(counter),
+      [](std::atomic<int>& Counter) -> tmc::task<void> {
+        ++Counter;
+        Counter.notify_all();
+        co_return;
+      }(counter)
+    );
+    ts.detach();
+    co_await counter;
+    EXPECT_EQ(counter.load(), 2);
   }());
 }


### PR DESCRIPTION
Expand coverage of assert-based protections against bad user behavior.

Cover full suite of run_on() / resume_on() / fork() / detach() combinations for spawn functions.

Cover other miscellaneous code paths that are otherwise not exercised by the test suite.