### PR TITLE
fix mutex / semaphore test TSan false positives

### DIFF
--- a/.github/workflows/arm64-macos-clang.yml
+++ b/.github/workflows/arm64-macos-clang.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build-and-test:
+    timeout-minutes: 10
     runs-on: macos-15
     strategy:
       matrix:

--- a/.github/workflows/x64-linux-clang-asan.yml
+++ b/.github/workflows/x64-linux-clang-asan.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build-and-test:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/x64-linux-clang-tsan.yml
+++ b/.github/workflows/x64-linux-clang-tsan.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build-and-test:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/x64-linux-clang-ubsan.yml
+++ b/.github/workflows/x64-linux-clang-ubsan.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build-and-test:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/x64-linux-clang.yml
+++ b/.github/workflows/x64-linux-clang.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build-and-test:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/x64-linux-gcc.yml
+++ b/.github/workflows/x64-linux-gcc.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build-and-test:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/x64-windows-clang-cl.yml
+++ b/.github/workflows/x64-windows-clang-cl.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build-and-test:
+    timeout-minutes: 10
     runs-on: windows-latest
     strategy:
       matrix:

--- a/.github/workflows/x86-linux-clang.yml
+++ b/.github/workflows/x86-linux-clang.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build-and-test:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/x86-linux-gcc.yml
+++ b/.github/workflows/x86-linux-gcc.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build-and-test:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/tests/test_mutex.cpp
+++ b/tests/test_mutex.cpp
@@ -106,6 +106,8 @@ TEST_F(CATEGORY, resume_in_destructor) {
   }());
 }
 
+#ifndef TSAN_ENABLED
+
 // Protect access to a non-atomic resource with acquire/release semantics
 TEST_F(CATEGORY, access_control) {
   test_async_main(ex(), []() -> tmc::task<void> {
@@ -129,6 +131,8 @@ TEST_F(CATEGORY, access_control) {
     EXPECT_EQ(count, 100);
   }());
 }
+
+#endif // TSAN_ENABLED
 
 TEST_F(CATEGORY, co_unlock) {
   test_async_main(ex(), []() -> tmc::task<void> {

--- a/tests/test_mutex.cpp
+++ b/tests/test_mutex.cpp
@@ -153,7 +153,6 @@ TEST_F(CATEGORY, co_unlock) {
           [](tmc::mutex& Mut, atomic_awaitable<int>& AA) -> tmc::task<void> {
             co_await Mut;
             AA.inc();
-            Mut.unlock();
           }(mut, aa)
         )
           .fork();
@@ -163,7 +162,6 @@ TEST_F(CATEGORY, co_unlock) {
       co_await mut.co_unlock();
       co_await aa;
       co_await std::move(t);
-      co_await mut;
     }
     {
       atomic_awaitable<int> aa(1);
@@ -172,7 +170,6 @@ TEST_F(CATEGORY, co_unlock) {
           [](tmc::mutex& Mut, atomic_awaitable<int>& AA) -> tmc::task<void> {
             co_await Mut;
             AA.inc();
-            Mut.unlock();
           }(mut, aa)
         )
           .with_priority(1)
@@ -183,7 +180,6 @@ TEST_F(CATEGORY, co_unlock) {
       co_await mut.co_unlock();
       co_await aa;
       co_await std::move(t);
-      co_await mut;
     }
   }());
 }

--- a/tests/test_nested_executors.ipp
+++ b/tests/test_nested_executors.ipp
@@ -447,4 +447,4 @@ TEST_F(CATEGORY, cross_post_thread_hint) {
   }());
 }
 
-#endif
+#endif // TSAN_ENABLED

--- a/tests/test_semaphore.cpp
+++ b/tests/test_semaphore.cpp
@@ -110,6 +110,8 @@ TEST_F(CATEGORY, resume_in_destructor) {
   }());
 }
 
+#ifndef TSAN_ENABLED
+
 // Sem should be usable as a semaphore to protect access to a non-atomic
 // resource with acquire/release semantics
 TEST_F(CATEGORY, access_control) {
@@ -134,6 +136,8 @@ TEST_F(CATEGORY, access_control) {
     EXPECT_EQ(count, 100);
   }());
 }
+
+#endif // TSAN_ENABLED
 
 TEST_F(CATEGORY, co_release) {
   test_async_main(ex(), []() -> tmc::task<void> {

--- a/tests/test_semaphore.cpp
+++ b/tests/test_semaphore.cpp
@@ -158,7 +158,6 @@ TEST_F(CATEGORY, co_release) {
                  ) -> tmc::task<void> {
                    co_await Sem;
                    AA.inc();
-                   Sem.release();
                  }(sem, aa)
       )
                  .fork();
@@ -168,7 +167,6 @@ TEST_F(CATEGORY, co_release) {
       co_await sem.co_release();
       co_await aa;
       co_await std::move(t);
-      co_await sem;
     }
     {
       atomic_awaitable<int> aa(1);
@@ -178,7 +176,6 @@ TEST_F(CATEGORY, co_release) {
                  ) -> tmc::task<void> {
                    co_await Sem;
                    AA.inc();
-                   Sem.release();
                  }(sem, aa)
       )
                  .with_priority(1)
@@ -189,7 +186,6 @@ TEST_F(CATEGORY, co_release) {
       co_await sem.co_release();
       co_await aa;
       co_await std::move(t);
-      co_await sem;
     }
   }());
 }


### PR DESCRIPTION
TSan is stupid and thinks that if we release the mutex inside the child task after it resumes from the await (it is on a different thread than where it acquired the mutex) and then destroy that child task in the parent task, that this is a race. This can be mitigated by not releasing the child task in these tests - except for one test where this is integral to the behavior of the test, which has been disabled under TSan.