### PR TITLE
Cleanup / add tests for auto_reset_event

### DIFF
--- a/tests/test_auto_reset_event.cpp
+++ b/tests/test_auto_reset_event.cpp
@@ -190,30 +190,28 @@ TEST_F(CATEGORY, co_set_no_symmetric) {
   test_async_main(ex(), []() -> tmc::task<void> {
     tmc::auto_reset_event event;
     EXPECT_EQ(event.is_set(), false);
-    {
-      atomic_awaitable<int> aa(1);
-      auto t = tmc::spawn(
-                 [](
-                   tmc::auto_reset_event& Event, atomic_awaitable<int>& AA
-                 ) -> tmc::task<void> {
-                   EXPECT_EQ(tmc::current_priority(), 1);
-                   co_await Event;
-                   EXPECT_EQ(tmc::current_priority(), 1);
-                   AA.inc();
-                 }(event, aa)
-      )
-                 .with_priority(1)
-                 .fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      EXPECT_EQ(event.is_set(), false);
-      EXPECT_EQ(aa.load(), 0);
-      EXPECT_EQ(tmc::current_priority(), 0);
-      co_await event.co_set();
-      EXPECT_EQ(tmc::current_priority(), 0);
-      co_await aa;
-      co_await std::move(t);
-      EXPECT_EQ(event.is_set(), false);
-    }
+    atomic_awaitable<int> aa(1);
+    auto t = tmc::spawn(
+               [](
+                 tmc::auto_reset_event& Event, atomic_awaitable<int>& AA
+               ) -> tmc::task<void> {
+                 EXPECT_EQ(tmc::current_priority(), 1);
+                 co_await Event;
+                 EXPECT_EQ(tmc::current_priority(), 1);
+                 AA.inc();
+               }(event, aa)
+    )
+               .with_priority(1)
+               .fork();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    EXPECT_EQ(event.is_set(), false);
+    EXPECT_EQ(aa.load(), 0);
+    EXPECT_EQ(tmc::current_priority(), 0);
+    co_await event.co_set();
+    EXPECT_EQ(tmc::current_priority(), 0);
+    co_await aa;
+    co_await std::move(t);
+    EXPECT_EQ(event.is_set(), false);
   }());
 }
 

--- a/tests/test_auto_reset_event.cpp
+++ b/tests/test_auto_reset_event.cpp
@@ -146,6 +146,7 @@ TEST_F(CATEGORY, multi_waiter_co_set) {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
       EXPECT_EQ(aa.load(), 0);
       co_await event.co_set();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
       EXPECT_EQ(aa.load(), 1);
       co_await event.co_set();
       co_await event.co_set();

--- a/tests/test_mutex.cpp
+++ b/tests/test_mutex.cpp
@@ -162,10 +162,10 @@ TEST_F(CATEGORY, access_control) {
           }(mut, count);
         }
       ),
-      100
+      1000
     );
     co_await mut;
-    EXPECT_EQ(count, 100);
+    EXPECT_EQ(count, 1000);
   }());
 }
 
@@ -186,14 +186,14 @@ TEST_F(CATEGORY, access_control_scope) {
             }(mut, count);
           }
         ),
-        100
+        1000
       )
         .fork();
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     mut.unlock();
     co_await std::move(ts);
     co_await mut;
-    EXPECT_EQ(count, 100);
+    EXPECT_EQ(count, 1000);
   }());
 }
 

--- a/tests/test_semaphore.cpp
+++ b/tests/test_semaphore.cpp
@@ -195,10 +195,10 @@ TEST_F(CATEGORY, access_control) {
           }(sem, count);
         }
       ),
-      100
+      1000
     );
     co_await sem;
-    EXPECT_EQ(count, 100);
+    EXPECT_EQ(count, 1000);
   }());
 }
 
@@ -218,14 +218,14 @@ TEST_F(CATEGORY, access_control_scope) {
             }(sem, count);
           }
         ),
-        100
+        1000
       )
         .fork();
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     sem.release();
     co_await std::move(ts);
     co_await sem;
-    EXPECT_EQ(count, 100);
+    EXPECT_EQ(count, 1000);
   }());
 }
 

--- a/tests/test_semaphore.cpp
+++ b/tests/test_semaphore.cpp
@@ -114,7 +114,7 @@ TEST_F(CATEGORY, multi_waiter_co_release) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     EXPECT_EQ(sem.count(), 0);
     EXPECT_EQ(aa.load(), 0);
-    sem.release(1);
+    co_await sem.co_release();
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     EXPECT_EQ(aa.load(), 1);
     co_await sem.co_release();


### PR DESCRIPTION
Tests for https://github.com/tzcnt/TooManyCooks/pull/110

auto_reset_event is now implemented using same base class as semaphore and should be usable as a semaphore, so the access_control test which is in place for mutex and semaphore has now also been added for auto_reset_event.