### PR TITLE
remove a tsan annotation

### DIFF
--- a/tests/test_ex_braid.cpp
+++ b/tests/test_ex_braid.cpp
@@ -20,9 +20,6 @@ protected:
   }
 
   static void TearDownTestSuite() {
-#ifdef TSAN_ENABLED
-    __tsan_acquire(&braid);
-#endif
     braid.reset();
     tmc::cpu_executor().teardown();
   }
@@ -54,10 +51,6 @@ TEST_F(CATEGORY, destroy_running_braid) {
     // A separately allocated boolean is used to track when this occurs and exit
     // the runloop safely.
   }());
-
-#ifdef TSAN_ENABLED
-  __tsan_release(&ex());
-#endif
 }
 
 #undef CATEGORY


### PR DESCRIPTION
I believe this annotation is no longer required with the rewrite of ex_braid on top of channel. I'm aiming to get TSan passing without any extra fuss like this.