### PR TITLE
Bring tmc-asio library into TooManyCooks repo

### DIFF
--- a/.github/workflows/arm64-macos-clang.yml
+++ b/.github/workflows/arm64-macos-clang.yml
@@ -23,14 +23,10 @@ jobs:
       run: >
         cd submodules
         && git clone https://github.com/tzcnt/TooManyCooks.git
-        && git clone https://github.com/tzcnt/tmc-asio.git
     # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
     - name: submodule-branch-TMC
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
-    - name: submodule-branch-tmc-asio
-      continue-on-error: true
-      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
       run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build

--- a/.github/workflows/x64-linux-clang-asan.yml
+++ b/.github/workflows/x64-linux-clang-asan.yml
@@ -23,14 +23,10 @@ jobs:
       run: >
         cd submodules
         && git clone https://github.com/tzcnt/TooManyCooks.git
-        && git clone https://github.com/tzcnt/tmc-asio.git
     # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
     - name: submodule-branch-TMC
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
-    - name: submodule-branch-tmc-asio
-      continue-on-error: true
-      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
       run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-fsanitize=address' -DCMD_LINK_FLAGS='-fsanitize=address' --preset ${{matrix.PRESET}} .
     - name: build

--- a/.github/workflows/x64-linux-clang-tsan.yml
+++ b/.github/workflows/x64-linux-clang-tsan.yml
@@ -23,14 +23,10 @@ jobs:
       run: >
         cd submodules
         && git clone https://github.com/tzcnt/TooManyCooks.git
-        && git clone https://github.com/tzcnt/tmc-asio.git
     # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
     - name: submodule-branch-TMC
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
-    - name: submodule-branch-tmc-asio
-      continue-on-error: true
-      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
       run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-fsanitize=thread' -DCMD_LINK_FLAGS='-fsanitize=thread' --preset ${{matrix.PRESET}} .
     - name: build

--- a/.github/workflows/x64-linux-clang-ubsan.yml
+++ b/.github/workflows/x64-linux-clang-ubsan.yml
@@ -23,14 +23,10 @@ jobs:
       run: >
         cd submodules
         && git clone https://github.com/tzcnt/TooManyCooks.git
-        && git clone https://github.com/tzcnt/tmc-asio.git
     # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
     - name: submodule-branch-TMC
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
-    - name: submodule-branch-tmc-asio
-      continue-on-error: true
-      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
       run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-fsanitize=undefined;-fno-sanitize-recover' -DCMD_LINK_FLAGS='-fsanitize=undefined' --preset ${{matrix.PRESET}} .
     - name: build

--- a/.github/workflows/x64-linux-clang.yml
+++ b/.github/workflows/x64-linux-clang.yml
@@ -23,14 +23,10 @@ jobs:
       run: >
         cd submodules
         && git clone https://github.com/tzcnt/TooManyCooks.git
-        && git clone https://github.com/tzcnt/tmc-asio.git
     # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
     - name: submodule-branch-TMC
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
-    - name: submodule-branch-tmc-asio
-      continue-on-error: true
-      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
       run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build

--- a/.github/workflows/x64-linux-gcc.yml
+++ b/.github/workflows/x64-linux-gcc.yml
@@ -23,14 +23,10 @@ jobs:
       run: >
         cd submodules
         && git clone https://github.com/tzcnt/TooManyCooks.git
-        && git clone https://github.com/tzcnt/tmc-asio.git
     # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
     - name: submodule-branch-TMC
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
-    - name: submodule-branch-tmc-asio
-      continue-on-error: true
-      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
       run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build

--- a/.github/workflows/x64-windows-clang-cl.yml
+++ b/.github/workflows/x64-windows-clang-cl.yml
@@ -23,14 +23,10 @@ jobs:
       run: >
         cd submodules
         && git clone https://github.com/tzcnt/TooManyCooks.git
-        && git clone https://github.com/tzcnt/tmc-asio.git
     # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
     - name: submodule-branch-TMC
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
-    - name: submodule-branch-tmc-asio
-      continue-on-error: true
-      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - uses: ilammy/msvc-dev-cmd@v1
     - name: configure
       run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .

--- a/.github/workflows/x86-linux-clang.yml
+++ b/.github/workflows/x86-linux-clang.yml
@@ -25,14 +25,10 @@ jobs:
       run: >
         cd submodules
         && git clone https://github.com/tzcnt/TooManyCooks.git
-        && git clone https://github.com/tzcnt/tmc-asio.git
     # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
     - name: submodule-branch-TMC
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
-    - name: submodule-branch-tmc-asio
-      continue-on-error: true
-      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
       run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build

--- a/.github/workflows/x86-linux-gcc.yml
+++ b/.github/workflows/x86-linux-gcc.yml
@@ -25,14 +25,10 @@ jobs:
       run: >
         cd submodules
         && git clone https://github.com/tzcnt/TooManyCooks.git
-        && git clone https://github.com/tzcnt/tmc-asio.git
     # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
     - name: submodule-branch-TMC
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
-    - name: submodule-branch-tmc-asio
-      continue-on-error: true
-      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
       run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,3 @@
 	path = submodules/TooManyCooks
 	url = https://github.com/tzcnt/TooManyCooks.git
 	branch = main
-[submodule "submodules/tmc-asio"]
-	path = submodules/tmc-asio
-	url = https://github.com/tzcnt/tmc-asio.git
-	branch = main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ option(TMC_AS_SUBMODULE "Download TMC repos as Git submodules" OFF)
 
 if(TMC_AS_SUBMODULE)
     set(TMC_INCLUDE_PATH ${tmc_examples_SOURCE_DIR}/submodules/TooManyCooks/include CACHE STRING "" FORCE)
-    set(TMC_ASIO_INCLUDE_PATH ${tmc_examples_SOURCE_DIR}/submodules/tmc-asio/include CACHE STRING "" FORCE)
 else()
     CPMAddPackage(
         NAME TooManyCooks
@@ -56,14 +55,7 @@ else()
         GIT_TAG main
         DOWNLOAD_ONLY)
 
-    CPMAddPackage(
-        NAME tmc_asio
-        GIT_REPOSITORY https://github.com/tzcnt/tmc-asio.git
-        GIT_TAG main
-        DOWNLOAD_ONLY)
-
     set(TMC_INCLUDE_PATH ${TooManyCooks_SOURCE_DIR}/include CACHE STRING "" FORCE)
-    set(TMC_ASIO_INCLUDE_PATH ${tmc_asio_SOURCE_DIR}/include CACHE STRING "" FORCE)
 endif()
 
 # TMC HWLOC support
@@ -237,10 +229,7 @@ if(WIN32)
     add_library(tmc_dll SHARED
         examples/standalone_compilation.cpp
     )
-    target_include_directories(tmc_dll PRIVATE
-        ${TMC_INCLUDE_PATH}
-        ${TMC_ASIO_INCLUDE_PATH}
-    )
+    target_include_directories(tmc_dll PRIVATE ${TMC_INCLUDE_PATH})
     target_compile_definitions(tmc_dll PRIVATE TMC_WINDOWS_DLL)
 
     if(TMC_USE_HWLOC)
@@ -259,10 +248,7 @@ endif()
 function(make_exe target_name)
     add_executable(${target_name} ${ARGN})
 
-    target_include_directories(${target_name} PRIVATE
-        ${TMC_INCLUDE_PATH}
-        ${TMC_ASIO_INCLUDE_PATH}
-    )
+    target_include_directories(${target_name} PRIVATE ${TMC_INCLUDE_PATH})
 
     if(TMC_USE_HWLOC)
         target_include_directories(${target_name} SYSTEM PRIVATE ${HWLOC_INCLUDE_PATH})

--- a/README.md
+++ b/README.md
@@ -3,13 +3,12 @@
 ![AddressSanitizer](https://github.com/tzcnt/tmc-examples/actions/workflows/x64-linux-clang-asan.yml/badge.svg) ![ThreadSanitizer](https://github.com/tzcnt/tmc-examples/actions/workflows/x64-linux-clang-tsan.yml/badge.svg) ![UndefinedBehaviorSanitizer](https://github.com/tzcnt/tmc-examples/actions/workflows/x64-linux-clang-ubsan.yml/badge.svg)
 
 ## tmc-examples
-This repository contains examples of how to use the TooManyCooks asynchronous runtime. The main TMC project repository can be found at:
+This repository contains examples of how to use the TooManyCooks asynchronous runtime. The main library project repository can be found at:
 https://github.com/tzcnt/TooManyCooks/
 
-Some of the examples also use other libraries in the TMC ecosystem:
-https://github.com/tzcnt/tmc-asio/
+Some of the examples also make use of the optional [Asio integration](https://github.com/tzcnt/TooManyCooks/tree/main/include/tmc/asio).
 
-This repository uses CMake to download and configure the TMC libraries, either as CPM packages (by default), or as git submodules (optionally). It provides a `CMakePresets.json` with configurations for Linux/Windows/MacOS and Clang/GCC/MSVC.
+This repository uses CMake to download and configure TooManyCooks, either as a CPM package (by default), or as git submodules (optionally). It provides a `CMakePresets.json` with configurations for Linux/Windows/MacOS and Clang/GCC/MSVC.
 
 ### Building
 Choose a value for `PRESET` from `CMakePresets.json` that is appropriate for your system.

--- a/examples/asio/README.md
+++ b/examples/asio/README.md
@@ -1,3 +1,3 @@
-Examples that demonstrate the usage of the tmc-asio companion library, which provides:
+Examples that demonstrate the usage of the tmc-asio optional library, which provides:
 - tmc::ex_asio - a single-threaded executor that wraps an asio::io_context
 - tmc::aw_asio - an asio completion token that is a TMC awaitable

--- a/examples/external/external_awaitable.cpp
+++ b/examples/external/external_awaitable.cpp
@@ -8,7 +8,7 @@
 // and restore awaiting tasks back to their original executors automatically (so
 // that this wrapper is not needed), see the implementation of
 // tmc::aw_asio_base::callback::operator() in
-// https://github.com/tzcnt/tmc-asio/blob/main/include/tmc/asio/aw_asio.hpp
+// https://github.com/tzcnt/TooManyCooks/blob/main/include/tmc/asio/aw_asio.hpp
 // as well as the specializations of tmc::detail::awaitable_traits in this repo.
 
 #include "../util/thread_name.hpp"

--- a/examples/external/external_executor.cpp
+++ b/examples/external/external_executor.cpp
@@ -1,7 +1,7 @@
 // Create an external executor that exposes all TMC compatibilities
 // by providing a specialization of tmc::detail::executor_traits.
 // For another example, see
-// https://github.com/tzcnt/tmc-asio/blob/main/include/tmc/asio/ex_asio.hpp
+// https://github.com/tzcnt/TooManyCooks/blob/main/include/tmc/asio/ex_asio.hpp
 
 #include "../util/thread_name.hpp"
 #include "tmc/detail/compat.hpp"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,10 +42,7 @@ function(make_exe_base target_name)
   target_link_libraries(${target_name} PRIVATE GTest::gtest_main)
 
   # Variables created by parent project
-  target_include_directories(${target_name} PRIVATE
-    ${TMC_INCLUDE_PATH}
-    ${TMC_ASIO_INCLUDE_PATH}
-  )
+  target_include_directories(${target_name} PRIVATE ${TMC_INCLUDE_PATH})
 
   # copy compile_commands.json to the build directory after build so clangd can find it
   # clangd won't look in the /build/{config} directory, only in the top-level /build directory
@@ -78,9 +75,7 @@ if(WIN32)
   target_link_libraries(tests_tmc_build_dll PRIVATE tmc_dll)
   target_link_libraries(tests_tmc_build_dll PRIVATE GTest::gtest_main)
   target_compile_definitions(tests_tmc_build_dll PRIVATE TMC_NO_UNKNOWN_AWAITABLES)
-  target_include_directories(tests_tmc_build_dll PRIVATE
-    ${TMC_INCLUDE_PATH}
-    ${TMC_ASIO_INCLUDE_PATH})
+  target_include_directories(tests_tmc_build_dll PRIVATE ${TMC_INCLUDE_PATH})
 
   if(TMC_USE_HWLOC)
     target_include_directories(tests_tmc_build_dll SYSTEM PUBLIC ${HWLOC_INCLUDE_PATH})
@@ -97,9 +92,7 @@ add_library(tests_tmc_build_lib OBJECT
 )
 target_link_libraries(tests_tmc_build_lib PRIVATE GTest::gtest_main)
 target_compile_definitions(tests_tmc_build_lib PRIVATE TMC_NO_UNKNOWN_AWAITABLES)
-target_include_directories(tests_tmc_build_lib PRIVATE
-  ${TMC_INCLUDE_PATH}
-  ${TMC_ASIO_INCLUDE_PATH})
+target_include_directories(tests_tmc_build_lib PRIVATE ${TMC_INCLUDE_PATH})
 
 if(TMC_USE_HWLOC)
   target_include_directories(tests_tmc_build_lib SYSTEM PUBLIC ${HWLOC_INCLUDE_PATH})


### PR DESCRIPTION
This simplifies build system deployments. The original plan was to debloat the library, but given that this is only 2 header files, it doesn't make a significant impact. Most of the "bloat" is in the examples and tests which are staying out.

This updates the examples and tests to remove all references to the old `tmc-asio` library. The includes are now available under `include/tmc/asio` - the same path as before, but in the main library.