### PR TITLE
TMC CMake project compatibility

### DIFF
--- a/.github/workflows/arm64-macos-clang.yml
+++ b/.github/workflows/arm64-macos-clang.yml
@@ -28,7 +28,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(sysctl -n hw.logicalcpu) --target all
     - name: run tests

--- a/.github/workflows/arm64-macos-clang.yml
+++ b/.github/workflows/arm64-macos-clang.yml
@@ -18,6 +18,8 @@ jobs:
         PRESET: [clang-macos-debug, clang-macos-release]
         WORK_ITEM: [CORO, FUNCORO]
     steps:
+    - name: install-hwloc
+      run: brew install hwloc
     - uses: actions/checkout@v4
     - name: submodule-clone
       run: >

--- a/.github/workflows/x64-linux-clang-asan.yml
+++ b/.github/workflows/x64-linux-clang-asan.yml
@@ -18,6 +18,8 @@ jobs:
         PRESET: [clang-linux-debug]
         WORK_ITEM: [CORO]
     steps:
+    - name: install-hwloc
+      run: sudo apt-get update && sudo apt-get install -y hwloc libhwloc-dev
     - uses: actions/checkout@v4
     - name: submodule-clone
       run: >

--- a/.github/workflows/x64-linux-clang-asan.yml
+++ b/.github/workflows/x64-linux-clang-asan.yml
@@ -28,7 +28,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-fsanitize=address' -DCMD_LINK_FLAGS='-fsanitize=address' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=address' -DCMD_LINK_FLAGS='-fsanitize=address' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang-tsan.yml
+++ b/.github/workflows/x64-linux-clang-tsan.yml
@@ -18,6 +18,8 @@ jobs:
         PRESET: [clang-linux-debug]
         WORK_ITEM: [CORO]
     steps:
+    - name: install-hwloc
+      run: sudo apt-get update && sudo apt-get install -y hwloc libhwloc-dev
     - uses: actions/checkout@v4
     - name: submodule-clone
       run: >

--- a/.github/workflows/x64-linux-clang-tsan.yml
+++ b/.github/workflows/x64-linux-clang-tsan.yml
@@ -28,7 +28,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-fsanitize=thread' -DCMD_LINK_FLAGS='-fsanitize=thread' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=thread' -DCMD_LINK_FLAGS='-fsanitize=thread' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang-ubsan.yml
+++ b/.github/workflows/x64-linux-clang-ubsan.yml
@@ -18,6 +18,8 @@ jobs:
         PRESET: [clang-linux-debug]
         WORK_ITEM: [CORO]
     steps:
+    - name: install-hwloc
+      run: sudo apt-get update && sudo apt-get install -y hwloc libhwloc-dev
     - uses: actions/checkout@v4
     - name: submodule-clone
       run: >

--- a/.github/workflows/x64-linux-clang-ubsan.yml
+++ b/.github/workflows/x64-linux-clang-ubsan.yml
@@ -28,7 +28,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-fsanitize=undefined;-fno-sanitize-recover' -DCMD_LINK_FLAGS='-fsanitize=undefined' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=undefined;-fno-sanitize-recover' -DCMD_LINK_FLAGS='-fsanitize=undefined' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang.yml
+++ b/.github/workflows/x64-linux-clang.yml
@@ -28,7 +28,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     # Core filenames will be of the form executable.pid.timestamp

--- a/.github/workflows/x64-linux-clang.yml
+++ b/.github/workflows/x64-linux-clang.yml
@@ -18,6 +18,8 @@ jobs:
         PRESET: [clang-linux-debug, clang-linux-release]
         WORK_ITEM: [CORO, FUNCORO]
     steps:
+    - name: install-hwloc
+      run: sudo apt-get update && sudo apt-get install -y hwloc libhwloc-dev
     - uses: actions/checkout@v4
     - name: submodule-clone
       run: >

--- a/.github/workflows/x64-linux-gcc.yml
+++ b/.github/workflows/x64-linux-gcc.yml
@@ -28,7 +28,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-gcc.yml
+++ b/.github/workflows/x64-linux-gcc.yml
@@ -18,6 +18,8 @@ jobs:
         PRESET: [gcc-linux-debug, gcc-linux-release]
         WORK_ITEM: [CORO, FUNCORO]
     steps:
+    - name: install-hwloc
+      run: sudo apt-get update && sudo apt-get install -y hwloc libhwloc-dev
     - uses: actions/checkout@v4
     - name: submodule-clone
       run: >

--- a/.github/workflows/x64-windows-clang-cl.yml
+++ b/.github/workflows/x64-windows-clang-cl.yml
@@ -29,7 +29,7 @@ jobs:
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - uses: ilammy/msvc-dev-cmd@v1
     - name: configure
-      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --target all
     - name: run tests

--- a/.github/workflows/x86-linux-clang.yml
+++ b/.github/workflows/x86-linux-clang.yml
@@ -30,7 +30,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x86-linux-clang.yml
+++ b/.github/workflows/x86-linux-clang.yml
@@ -30,7 +30,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x86-linux-gcc.yml
+++ b/.github/workflows/x86-linux-gcc.yml
@@ -30,7 +30,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x86-linux-gcc.yml
+++ b/.github/workflows/x86-linux-gcc.yml
@@ -30,7 +30,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,14 +22,29 @@ endif()
 
 include(cmake/CPM.cmake)
 
-# By default, download the TMC repos as CPM packages.
-# If this option is enabled, CMake will expect them to be in git submodules.
-# You must run `submodule update --init --recursive` before turning this on.
-# This option exists to simplify my development across repositories.
-option(TMC_AS_SUBMODULE "Download TMC repos as Git submodules" OFF)
-
-# Mirror TooManyCooks' default before adding it so Windows can provide hwloc::hwloc.
+# TooManyCooks options. Set these before add_subdirectory()/CPMAddPackage()
+# so they are applied to the TooManyCooks::TooManyCooks interface target.
+# Defaults are specified below.
 option(TMC_USE_HWLOC "Enable hwloc topology-aware thread placement" ON)
+option(TMC_USE_BOOST_ASIO "Use boost::asio instead of standalone asio" OFF)
+
+set(TMC_WORK_ITEM "CORO" CACHE STRING "Work item type: CORO or FUNCORO")
+set_property(CACHE TMC_WORK_ITEM PROPERTY STRINGS "CORO" "FUNCORO")
+
+option(TMC_TRIVIAL_TASK "Enable trivial task optimization" OFF)
+option(TMC_NODISCARD_AWAIT "Enable [[nodiscard]] on co_await" OFF)
+
+set(TMC_PRIORITY_COUNT "" CACHE STRING "Number of priority levels (1-16, empty for runtime-configurable)")
+
+option(TMC_MORE_THREADS "Allow more than 64 threads" OFF)
+option(TMC_DEBUG_TASK_ALLOC_COUNT "Track task allocation count for HALO analysis" OFF)
+option(TMC_DEBUG_THREAD_CREATION "Print thread creation and work stealing info" OFF)
+
+option(TMC_STANDALONE_COMPILATION "Disable header-only mode. Library will be built into the file that defines TMC_IMPL" OFF)
+
+if(WIN32)
+    option(TMC_WINDOWS_DLL "Enable Windows DLL mode" OFF)
+endif()
 
 # On Windows, download hwloc binaries before adding TooManyCooks
 # so that its CMakeLists.txt can find them.
@@ -53,6 +68,12 @@ if(WIN32 AND TMC_USE_HWLOC)
         INTERFACE_INCLUDE_DIRECTORIES "${hwloc_SOURCE_DIR}/include"
     )
 endif()
+
+# By default, download the TMC repos as CPM packages.
+# If this option is enabled, CMake will expect them to be in git submodules.
+# You must run `submodule update --init --recursive` before turning this on.
+# This option exists to simplify my development across repositories.
+option(TMC_AS_SUBMODULE "Download TMC repos as Git submodules" OFF)
 
 if(TMC_AS_SUBMODULE)
     add_subdirectory(submodules/TooManyCooks)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ endif()
 link_libraries(${MALLOC_LIB})
 
 # Standalone asio or boost::asio support
-# The tmc::tmc target propagates the TMC_USE_BOOST_ASIO define, but does not
+# The TooManyCooks::TooManyCooks target propagates the TMC_USE_BOOST_ASIO define, but does not
 # provide the asio or boost::asio headers. The consumer must make them available
 # (e.g. via find_package, CPM, or system install) before including tmc-asio headers.
 if(TMC_USE_BOOST_ASIO)
@@ -181,7 +181,7 @@ if(WIN32)
     add_library(tmc_dll SHARED
         examples/standalone_compilation.cpp
     )
-    target_link_libraries(tmc_dll PRIVATE tmc::tmc)
+    target_link_libraries(tmc_dll PRIVATE TooManyCooks::TooManyCooks)
     target_compile_definitions(tmc_dll PRIVATE TMC_WINDOWS_DLL)
 
     if(TMC_USE_HWLOC)
@@ -196,7 +196,7 @@ endif()
 function(make_exe target_name)
     add_executable(${target_name} ${ARGN})
 
-    target_link_libraries(${target_name} PRIVATE tmc::tmc)
+    target_link_libraries(${target_name} PRIVATE TooManyCooks::TooManyCooks)
 
     # copy compile_commands.json to the build directory after build so clangd can find it
     # clangd won't look in the /build/{PRESET} directory, only in the top-level /build directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,16 +146,6 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         "-Wno-exit-time-destructors"
     )
 
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "21.0")
-        add_definitions(
-
-            # This is a real problem, however it only occurs in a specific scenario.
-            # It prevents TMC being used in multiple DLLs within the same program, on Windows only.
-            # This problem does not occur when using static linking.
-            "-Wno-unique-object-duplication"
-        )
-    endif()
-
     if(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
         add_definitions(
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,9 @@ endif()
 link_libraries(${MALLOC_LIB})
 
 # Standalone asio or boost::asio support
+# The tmc::tmc target propagates the TMC_USE_BOOST_ASIO define, but does not
+# provide the asio or boost::asio headers. The consumer must make them available
+# (e.g. via find_package, CPM, or system install) before including tmc-asio headers.
 if(TMC_USE_BOOST_ASIO)
     # Tell cmake to use the target Boost cmake file instead of the built-in
     cmake_policy(SET CMP0167 NEW)
@@ -179,6 +182,7 @@ if(WIN32)
         examples/standalone_compilation.cpp
     )
     target_link_libraries(tmc_dll PRIVATE tmc::tmc)
+    target_compile_definitions(tmc_dll PRIVATE TMC_WINDOWS_DLL)
 
     if(TMC_USE_HWLOC)
         add_custom_command(TARGET tmc_dll POST_BUILD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,24 +9,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS "1")
 
 set(CMAKE_CXX_STANDARD 20)
 
-add_definitions(
-
-    # #### Performance tuning options #####
-    # "-DTMC_WORK_ITEM=CORO" # one of: CORO, FUNC, FUNCORO
-    # "-DTMC_TRIVIAL_TASK" # enabled in this repo for Release builds via CMakePresets.json
-    # "-DTMC_PRIORITY_COUNT=1" # unsigned integer between 1 and 63
-    # "-DTMC_MORE_THREADS" # allows more than 64 threads
-
-    # #### Debug / diagnostics options #####
-    # ## Tracks the number of tmc::task allocations, which lets you determine
-    # ## how effectively Heap Allocation Elision (HALO) is being applied by the compiler.
-    # "-DTMC_DEBUG_TASK_ALLOC_COUNT"
-
-    # ## Prints information about work stealing matrixes.
-    # ## If TMC_USE_HWLOC is enabled, also prints info about thread grouping and thread affinity.
-    # "-DTMC_DEBUG_THREAD_CREATION"
-)
-
 # Optional flags can be passed at the command line. Used by GitHub Actions workflow.
 if(CMD_COMPILE_FLAGS)
     message(STATUS "CMD_COMPILE_FLAGS: ${CMD_COMPILE_FLAGS}")
@@ -46,53 +28,36 @@ include(cmake/CPM.cmake)
 # This option exists to simplify my development across repositories.
 option(TMC_AS_SUBMODULE "Download TMC repos as Git submodules" OFF)
 
+# On Windows, download hwloc binaries before adding TooManyCooks
+# so that its CMakeLists.txt can find them.
+if(WIN32 AND TMC_USE_HWLOC)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(PLATFORM_BITS 64)
+    else()
+        set(PLATFORM_BITS 32)
+    endif()
+
+    CPMAddPackage(
+        NAME hwloc
+        URL "https://download.open-mpi.org/release/hwloc/v2.12/hwloc-win${PLATFORM_BITS}-build-2.12.2.zip"
+        VERSION 2.12.2
+        DOWNLOAD_ONLY
+    )
+
+    add_library(hwloc::hwloc UNKNOWN IMPORTED)
+    set_target_properties(hwloc::hwloc PROPERTIES
+        IMPORTED_LOCATION "${hwloc_SOURCE_DIR}/lib/libhwloc.lib"
+        INTERFACE_INCLUDE_DIRECTORIES "${hwloc_SOURCE_DIR}/include"
+    )
+endif()
+
 if(TMC_AS_SUBMODULE)
-    set(TMC_INCLUDE_PATH ${tmc_examples_SOURCE_DIR}/submodules/TooManyCooks/include CACHE STRING "" FORCE)
+    add_subdirectory(submodules/TooManyCooks)
 else()
     CPMAddPackage(
         NAME TooManyCooks
         GIT_REPOSITORY https://github.com/tzcnt/TooManyCooks.git
-        GIT_TAG main
-        DOWNLOAD_ONLY)
-
-    set(TMC_INCLUDE_PATH ${TooManyCooks_SOURCE_DIR}/include CACHE STRING "" FORCE)
-endif()
-
-# TMC HWLOC support
-option(TMC_USE_HWLOC "libhwloc" ON)
-
-if(TMC_USE_HWLOC)
-    if(WIN32)
-        if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-            set(PLATFORM_BITS 64)
-        else()
-            set(PLATFORM_BITS 32)
-        endif()
-
-        # Finding user-provided libraries on Windows is a hassle. For this example, just get the built .lib and .dll directly.
-        CPMAddPackage(
-            NAME hwloc
-            URL "https://download.open-mpi.org/release/hwloc/v2.12/hwloc-win${PLATFORM_BITS}-build-2.12.2.zip"
-            VERSION 2.12.2
-            DOWNLOAD_ONLY
-        )
-        link_libraries(${hwloc_SOURCE_DIR}/lib/libhwloc.lib)
-        set(HWLOC_INCLUDE_PATH ${hwloc_SOURCE_DIR}/include CACHE STRING "" FORCE)
-        add_compile_definitions(TMC_USE_HWLOC)
-    else()
-        message(STATUS "TMC_USE_HWLOC: running find_package(libhwloc)...")
-        find_package(libhwloc)
-
-        if(NOT LIBHWLOC_FOUND)
-            message(STATUS "WARNING: Package libhwloc not found. hwloc integration will be disabled.")
-        else()
-            message(STATUS "TMC_USE_HWLOC: found library ${LIBHWLOC_LIBRARY}")
-            message(STATUS "TMC_USE_HWLOC: found include ${LIBHWLOC_INCLUDE_DIR}/hwloc.h")
-            link_libraries(${LIBHWLOC_LIBRARY})
-            set(HWLOC_INCLUDE_PATH ${LIBHWLOC_INCLUDE_DIR} CACHE STRING "" FORCE)
-            add_compile_definitions(TMC_USE_HWLOC)
-        endif()
-    endif()
+        GIT_TAG main)
 endif()
 
 # Since each new coroutine requires an allocation,
@@ -126,17 +91,11 @@ endif()
 link_libraries(${MALLOC_LIB})
 
 # Standalone asio or boost::asio support
-option(TMC_USE_BOOST_ASIO "Use boost::asio instead of standalone asio" OFF)
-
 if(TMC_USE_BOOST_ASIO)
-    add_compile_definitions(TMC_USE_BOOST_ASIO)
-
     # Tell cmake to use the target Boost cmake file instead of the built-in
     cmake_policy(SET CMP0167 NEW)
     set(Boost_USE_STATIC_LIBS ON)
     set(Boost_USE_RELEASE_LIBS ON)
-
-    # set(ENV{BOOST_CMAKE_ROOT} "/home/tzcnt/pkg-src/boost-1.88-src/boost_1_88_0/stage/lib/cmake/")
 
     # By default this will will look for your system boost.
     # If this fails you can install boost manually and set the system environment variable
@@ -229,12 +188,7 @@ if(WIN32)
     add_library(tmc_dll SHARED
         examples/standalone_compilation.cpp
     )
-    target_include_directories(tmc_dll PRIVATE ${TMC_INCLUDE_PATH})
-    target_compile_definitions(tmc_dll PRIVATE TMC_WINDOWS_DLL)
-
-    if(TMC_USE_HWLOC)
-        target_include_directories(tmc_dll SYSTEM PRIVATE ${HWLOC_INCLUDE_PATH})
-    endif()
+    target_link_libraries(tmc_dll PRIVATE tmc::tmc)
 
     if(TMC_USE_HWLOC)
         add_custom_command(TARGET tmc_dll POST_BUILD
@@ -248,11 +202,7 @@ endif()
 function(make_exe target_name)
     add_executable(${target_name} ${ARGN})
 
-    target_include_directories(${target_name} PRIVATE ${TMC_INCLUDE_PATH})
-
-    if(TMC_USE_HWLOC)
-        target_include_directories(${target_name} SYSTEM PRIVATE ${HWLOC_INCLUDE_PATH})
-    endif()
+    target_link_libraries(${target_name} PRIVATE tmc::tmc)
 
     # copy compile_commands.json to the build directory after build so clangd can find it
     # clangd won't look in the /build/{PRESET} directory, only in the top-level /build directory
@@ -263,7 +213,6 @@ function(make_exe target_name)
     )
 
     if(TMC_USE_DLL)
-        target_compile_definitions(${target_name} PRIVATE TMC_WINDOWS_DLL)
         target_link_libraries(${target_name} PRIVATE tmc_dll)
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,8 @@ endif()
 # add_link_options("-fsanitize=thread")
 # add_definitions("-fsanitize=undefined -fno-sanitize-recover")
 # add_link_options("-fsanitize=undefined")
+
+# Demonstrating how to link TMC into a DLL
 if(WIN32)
     option(TMC_USE_DLL "Link all targets against tmc_dll shared library. Requires TMC_WINDOWS_DLL=ON" OFF)
 
@@ -221,10 +223,21 @@ if(WIN32)
     endif()
 endif()
 
+if(TMC_STANDALONE_COMPILATION AND NOT TMC_USE_DLL)
+    add_library(tmc_standalone_compilation OBJECT
+        examples/standalone_compilation.cpp
+    )
+    target_link_libraries(tmc_standalone_compilation PRIVATE TooManyCooks::TooManyCooks)
+endif()
+
 function(make_exe target_name)
     add_executable(${target_name} ${ARGN})
 
     target_link_libraries(${target_name} PRIVATE TooManyCooks::TooManyCooks)
+
+    if(TMC_STANDALONE_COMPILATION AND NOT TMC_USE_DLL)
+        target_link_libraries(${target_name} PRIVATE tmc_standalone_compilation)
+    endif()
 
     # copy compile_commands.json to the build directory after build so clangd can find it
     # clangd won't look in the /build/{PRESET} directory, only in the top-level /build directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ include(cmake/CPM.cmake)
 # This option exists to simplify my development across repositories.
 option(TMC_AS_SUBMODULE "Download TMC repos as Git submodules" OFF)
 
+# Mirror TooManyCooks' default before adding it so Windows can provide hwloc::hwloc.
+option(TMC_USE_HWLOC "Enable hwloc topology-aware thread placement" ON)
+
 # On Windows, download hwloc binaries before adding TooManyCooks
 # so that its CMakeLists.txt can find them.
 if(WIN32 AND TMC_USE_HWLOC)
@@ -175,7 +178,11 @@ endif()
 # add_definitions("-fsanitize=undefined -fno-sanitize-recover")
 # add_link_options("-fsanitize=undefined")
 if(WIN32)
-    option(TMC_USE_DLL "Link all targets against tmc_dll shared library" OFF)
+    option(TMC_USE_DLL "Link all targets against tmc_dll shared library. Requires TMC_WINDOWS_DLL=ON" OFF)
+
+    if(TMC_USE_DLL AND NOT TMC_WINDOWS_DLL)
+        message(FATAL_ERROR "TMC_USE_DLL requires TMC_WINDOWS_DLL=ON")
+    endif()
 
     # A shared library (DLL) containing the TMC standalone compilation
     add_library(tmc_dll SHARED

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -33,9 +33,10 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
-        "CMAKE_CXX_FLAGS": "-march=native -DTMC_TRIVIAL_TASK",
+        "CMAKE_CXX_FLAGS": "-march=native",
         "CMAKE_C_FLAGS": "-march=native",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "TMC_TRIVIAL_TASK": "ON"
       },
       "condition": {
         "type": "equals",
@@ -96,9 +97,10 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_C_COMPILER": "gcc",
         "CMAKE_CXX_COMPILER": "g++",
-        "CMAKE_CXX_FLAGS": "-march=native -DTMC_TRIVIAL_TASK",
+        "CMAKE_CXX_FLAGS": "-march=native",
         "CMAKE_C_FLAGS": "-march=native",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "TMC_TRIVIAL_TASK": "ON"
       },
       "condition": {
         "type": "equals",
@@ -172,9 +174,10 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_C_COMPILER": "clang-cl.exe",
         "CMAKE_CXX_COMPILER": "clang-cl.exe",
-        "CMAKE_CXX_FLAGS": "/DTMC_TRIVIAL_TASK /DWIN32 /D_WINDOWS /W4 /GR /EHsc -march=native",
+        "CMAKE_CXX_FLAGS": "/DWIN32 /D_WINDOWS /W4 /GR /EHsc -march=native",
         "CMAKE_C_FLAGS": "/DWIN32 /D_WINDOWS /W4 -march=native",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "TMC_TRIVIAL_TASK": "ON"
       },
       "architecture": {
         "value": "x64",
@@ -275,8 +278,9 @@
         "CMAKE_C_COMPILER": "cl.exe",
         "CMAKE_CXX_COMPILER": "cl.exe",
         "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
-        "CMAKE_CXX_FLAGS": "/DTMC_TRIVIAL_TASK /DWIN32 /D_WINDOWS /W4 /GR /EHsc /arch:AVX2",
-        "CMAKE_C_FLAGS": "/DWIN32 /D_WINDOWS /W4 /arch:AVX2"
+        "CMAKE_CXX_FLAGS": "/DWIN32 /D_WINDOWS /W4 /GR /EHsc /arch:AVX2",
+        "CMAKE_C_FLAGS": "/DWIN32 /D_WINDOWS /W4 /arch:AVX2",
+        "TMC_TRIVIAL_TASK": "ON"
       },
       "architecture": {
         "value": "x64",
@@ -361,9 +365,10 @@
         "CMAKE_BUILD_TYPE": "Release",
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
-        "CMAKE_CXX_FLAGS": "-march=native -DTMC_TRIVIAL_TASK -fexperimental-library",
+        "CMAKE_CXX_FLAGS": "-march=native -fexperimental-library",
         "CMAKE_C_FLAGS": "-march=native",
-        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "TMC_TRIVIAL_TASK": "ON"
       },
       "environment": {
         "CMAKE_BUILD_PARALLEL_LEVEL": "8"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 function(make_exe_base target_name)
   add_executable(${target_name} ${ARGN})
   target_link_libraries(${target_name} PRIVATE GTest::gtest_main)
-  target_link_libraries(${target_name} PRIVATE tmc::tmc)
+  target_link_libraries(${target_name} PRIVATE TooManyCooks::TooManyCooks)
 
   # Tests use standalone compilation to speedup the build + test the hwloc.h isolation
   target_compile_definitions(${target_name} PRIVATE TMC_STANDALONE_COMPILATION)
@@ -73,7 +73,7 @@ if(WIN32)
   target_compile_definitions(tests_tmc_build_dll PRIVATE TMC_WINDOWS_DLL)
   target_link_libraries(tests_tmc_build_dll PRIVATE tmc_dll)
   target_link_libraries(tests_tmc_build_dll PRIVATE GTest::gtest_main)
-  target_link_libraries(tests_tmc_build_dll PRIVATE tmc::tmc)
+  target_link_libraries(tests_tmc_build_dll PRIVATE TooManyCooks::TooManyCooks)
   target_compile_definitions(tests_tmc_build_dll PRIVATE TMC_STANDALONE_COMPILATION TMC_NO_UNKNOWN_AWAITABLES)
 endif()
 
@@ -86,7 +86,7 @@ add_library(tests_tmc_build_lib OBJECT
   standalone_compilation.cpp
 )
 target_link_libraries(tests_tmc_build_lib PRIVATE GTest::gtest_main)
-target_link_libraries(tests_tmc_build_lib PRIVATE tmc::tmc)
+target_link_libraries(tests_tmc_build_lib PRIVATE TooManyCooks::TooManyCooks)
 target_compile_definitions(tests_tmc_build_lib PRIVATE TMC_STANDALONE_COMPILATION TMC_NO_UNKNOWN_AWAITABLES)
 
 make_exe_base(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,13 +35,27 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL 
   )
 endif()
 
+add_library(tmc_test_common INTERFACE)
+target_link_libraries(tmc_test_common INTERFACE
+  GTest::gtest_main
+  TooManyCooks::TooManyCooks
+)
+
+# Most tests use standalone compilation to speed up the build + test the hwloc.h isolation.
+target_compile_definitions(tmc_test_common INTERFACE TMC_STANDALONE_COMPILATION)
+
+add_library(tmc_test_no_unknown_awaitables INTERFACE)
+target_compile_definitions(tmc_test_no_unknown_awaitables INTERFACE TMC_NO_UNKNOWN_AWAITABLES)
+
+set(TMC_HWLOC_TEST_SOURCES
+  fixtures/topo_13600k.cpp
+  test_hwloc.cpp
+  test_hwloc_synthetic.cpp
+)
+
 function(make_exe_base target_name)
   add_executable(${target_name} ${ARGN})
-  target_link_libraries(${target_name} PRIVATE GTest::gtest_main)
-  target_link_libraries(${target_name} PRIVATE TooManyCooks::TooManyCooks)
-
-  # Tests use standalone compilation to speedup the build + test the hwloc.h isolation
-  target_compile_definitions(${target_name} PRIVATE TMC_STANDALONE_COMPILATION)
+  target_link_libraries(${target_name} PRIVATE tmc_test_common)
 
   # copy compile_commands.json to the build directory after build so clangd can find it
   # clangd won't look in the /build/{config} directory, only in the top-level /build directory
@@ -66,28 +80,22 @@ endfunction()
 if(WIN32)
   # This doesn't include the TMC definitions - those come from tmc_build.dll
   add_library(tests_tmc_build_dll STATIC
-    fixtures/topo_13600k.cpp
-    test_hwloc.cpp
-    test_hwloc_synthetic.cpp
+    ${TMC_HWLOC_TEST_SOURCES}
   )
   target_compile_definitions(tests_tmc_build_dll PRIVATE TMC_WINDOWS_DLL)
   target_link_libraries(tests_tmc_build_dll PRIVATE tmc_dll)
-  target_link_libraries(tests_tmc_build_dll PRIVATE GTest::gtest_main)
-  target_link_libraries(tests_tmc_build_dll PRIVATE TooManyCooks::TooManyCooks)
-  target_compile_definitions(tests_tmc_build_dll PRIVATE TMC_STANDALONE_COMPILATION TMC_NO_UNKNOWN_AWAITABLES)
+  target_link_libraries(tests_tmc_build_dll PRIVATE tmc_test_common)
+  target_link_libraries(tests_tmc_build_dll PRIVATE tmc_test_no_unknown_awaitables)
 endif()
 
 # This includes the TMC definitions.
 # Whether this or the DLL target is linked to tests depends on whether TMC_WINDOWS_DLL is defined.
 add_library(tests_tmc_build_lib OBJECT
-  fixtures/topo_13600k.cpp
-  test_hwloc.cpp
-  test_hwloc_synthetic.cpp
+  ${TMC_HWLOC_TEST_SOURCES}
   standalone_compilation.cpp
 )
-target_link_libraries(tests_tmc_build_lib PRIVATE GTest::gtest_main)
-target_link_libraries(tests_tmc_build_lib PRIVATE TooManyCooks::TooManyCooks)
-target_compile_definitions(tests_tmc_build_lib PRIVATE TMC_STANDALONE_COMPILATION TMC_NO_UNKNOWN_AWAITABLES)
+target_link_libraries(tests_tmc_build_lib PRIVATE tmc_test_common)
+target_link_libraries(tests_tmc_build_lib PRIVATE tmc_test_no_unknown_awaitables)
 
 make_exe_base(
   tests
@@ -128,7 +136,7 @@ make_exe_base(
   test_container.cpp
   test_traits.cpp
 )
-target_compile_definitions(tests PRIVATE TMC_NO_UNKNOWN_AWAITABLES)
+target_link_libraries(tests PRIVATE tmc_test_no_unknown_awaitables)
 
 if(TMC_USE_DLL)
   target_compile_definitions(tests PRIVATE TMC_WINDOWS_DLL)
@@ -153,12 +161,13 @@ endfunction()
 make_exe(test_exceptions test_exceptions.cpp)
 
 make_exe(test_halo test_halo.cpp)
-target_compile_definitions(test_halo PRIVATE TMC_DEBUG_TASK_ALLOC_COUNT TMC_NO_UNKNOWN_AWAITABLES)
+target_compile_definitions(test_halo PRIVATE TMC_DEBUG_TASK_ALLOC_COUNT)
+target_link_libraries(test_halo PRIVATE tmc_test_no_unknown_awaitables)
 
 make_exe(test_fuzz_chan test_fuzz_chan.cpp)
-target_compile_definitions(test_fuzz_chan PRIVATE TMC_NO_UNKNOWN_AWAITABLES)
+target_link_libraries(test_fuzz_chan PRIVATE tmc_test_no_unknown_awaitables)
 
 make_exe(test_container test_container.cpp)
-target_compile_definitions(test_container PRIVATE TMC_NO_UNKNOWN_AWAITABLES)
+target_link_libraries(test_container PRIVATE tmc_test_no_unknown_awaitables)
 
 gtest_discover_tests(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,13 +36,12 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL 
 endif()
 
 function(make_exe_base target_name)
-  # Tests use standalone compilation to speedup the build + test the hwloc.h isolation
-  add_compile_definitions(TMC_STANDALONE_COMPILATION)
   add_executable(${target_name} ${ARGN})
   target_link_libraries(${target_name} PRIVATE GTest::gtest_main)
+  target_link_libraries(${target_name} PRIVATE tmc::tmc)
 
-  # Variables created by parent project
-  target_include_directories(${target_name} PRIVATE ${TMC_INCLUDE_PATH})
+  # Tests use standalone compilation to speedup the build + test the hwloc.h isolation
+  target_compile_definitions(${target_name} PRIVATE TMC_STANDALONE_COMPILATION)
 
   # copy compile_commands.json to the build directory after build so clangd can find it
   # clangd won't look in the /build/{config} directory, only in the top-level /build directory
@@ -74,12 +73,8 @@ if(WIN32)
   target_compile_definitions(tests_tmc_build_dll PRIVATE TMC_WINDOWS_DLL)
   target_link_libraries(tests_tmc_build_dll PRIVATE tmc_dll)
   target_link_libraries(tests_tmc_build_dll PRIVATE GTest::gtest_main)
-  target_compile_definitions(tests_tmc_build_dll PRIVATE TMC_NO_UNKNOWN_AWAITABLES)
-  target_include_directories(tests_tmc_build_dll PRIVATE ${TMC_INCLUDE_PATH})
-
-  if(TMC_USE_HWLOC)
-    target_include_directories(tests_tmc_build_dll SYSTEM PUBLIC ${HWLOC_INCLUDE_PATH})
-  endif()
+  target_link_libraries(tests_tmc_build_dll PRIVATE tmc::tmc)
+  target_compile_definitions(tests_tmc_build_dll PRIVATE TMC_STANDALONE_COMPILATION TMC_NO_UNKNOWN_AWAITABLES)
 endif()
 
 # This includes the TMC definitions.
@@ -91,12 +86,8 @@ add_library(tests_tmc_build_lib OBJECT
   standalone_compilation.cpp
 )
 target_link_libraries(tests_tmc_build_lib PRIVATE GTest::gtest_main)
-target_compile_definitions(tests_tmc_build_lib PRIVATE TMC_NO_UNKNOWN_AWAITABLES)
-target_include_directories(tests_tmc_build_lib PRIVATE ${TMC_INCLUDE_PATH})
-
-if(TMC_USE_HWLOC)
-  target_include_directories(tests_tmc_build_lib SYSTEM PUBLIC ${HWLOC_INCLUDE_PATH})
-endif()
+target_link_libraries(tests_tmc_build_lib PRIVATE tmc::tmc)
+target_compile_definitions(tests_tmc_build_lib PRIVATE TMC_STANDALONE_COMPILATION TMC_NO_UNKNOWN_AWAITABLES)
 
 make_exe_base(
   tests
@@ -157,10 +148,6 @@ endif()
 function(make_exe target_name)
   make_exe_base(${target_name} ${ARGN})
   target_sources(${target_name} PRIVATE standalone_compilation.cpp)
-
-  if(TMC_USE_HWLOC)
-    target_include_directories(${target_name} SYSTEM PRIVATE ${HWLOC_INCLUDE_PATH})
-  endif()
 endfunction()
 
 make_exe(test_exceptions test_exceptions.cpp)
@@ -173,13 +160,5 @@ target_compile_definitions(test_fuzz_chan PRIVATE TMC_NO_UNKNOWN_AWAITABLES)
 
 make_exe(test_container test_container.cpp)
 target_compile_definitions(test_container PRIVATE TMC_NO_UNKNOWN_AWAITABLES)
-
-if(TMC_USE_HWLOC AND LIBHWLOC_FOUND)
-  target_link_libraries(tests PRIVATE ${LIBHWLOC_LIBRARY})
-  target_link_libraries(test_exceptions PRIVATE ${LIBHWLOC_LIBRARY})
-  target_link_libraries(test_halo PRIVATE ${LIBHWLOC_LIBRARY})
-  target_link_libraries(test_fuzz_chan PRIVATE ${LIBHWLOC_LIBRARY})
-  target_link_libraries(test_container PRIVATE ${LIBHWLOC_LIBRARY})
-endif()
 
 gtest_discover_tests(tests)


### PR DESCRIPTION
Make use of the changes in https://github.com/tzcnt/TooManyCooks/pull/222

- call `target_link_libraries(${target_name} PRIVATE TooManyCooks::TooManyCooks)`
- set CMake options instead of compile definitions directly