### PR TITLE
disable copy compile commands in CI

### DIFF
--- a/.github/workflows/arm64-macos-clang.yml
+++ b/.github/workflows/arm64-macos-clang.yml
@@ -30,7 +30,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(sysctl -n hw.logicalcpu) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang-asan.yml
+++ b/.github/workflows/x64-linux-clang-asan.yml
@@ -30,7 +30,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=address' -DCMD_LINK_FLAGS='-fsanitize=address' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=address' -DCMD_LINK_FLAGS='-fsanitize=address' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang-tsan.yml
+++ b/.github/workflows/x64-linux-clang-tsan.yml
@@ -30,7 +30,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=thread' -DCMD_LINK_FLAGS='-fsanitize=thread' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=thread' -DCMD_LINK_FLAGS='-fsanitize=thread' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang-ubsan.yml
+++ b/.github/workflows/x64-linux-clang-ubsan.yml
@@ -30,7 +30,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=undefined;-fno-sanitize-recover' -DCMD_LINK_FLAGS='-fsanitize=undefined' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=undefined;-fno-sanitize-recover' -DCMD_LINK_FLAGS='-fsanitize=undefined' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang.yml
+++ b/.github/workflows/x64-linux-clang.yml
@@ -30,7 +30,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     # Core filenames will be of the form executable.pid.timestamp

--- a/.github/workflows/x64-linux-gcc.yml
+++ b/.github/workflows/x64-linux-gcc.yml
@@ -30,7 +30,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-windows-clang-cl.yml
+++ b/.github/workflows/x64-windows-clang-cl.yml
@@ -29,7 +29,7 @@ jobs:
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - uses: ilammy/msvc-dev-cmd@v1
     - name: configure
-      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --target all
     - name: run tests

--- a/.github/workflows/x86-linux-clang.yml
+++ b/.github/workflows/x86-linux-clang.yml
@@ -30,7 +30,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_USE_HWLOC=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x86-linux-gcc.yml
+++ b/.github/workflows/x86-linux-gcc.yml
@@ -30,7 +30,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_USE_HWLOC=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,11 +241,17 @@ function(make_exe target_name)
 
     # copy compile_commands.json to the build directory after build so clangd can find it
     # clangd won't look in the /build/{PRESET} directory, only in the top-level /build directory
-    add_custom_command(TARGET ${target_name} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        ${CMAKE_BINARY_DIR}/compile_commands.json
-        ${CMAKE_CURRENT_LIST_DIR}/build
-    )
+
+    # this often fails on GitHub Actions for some reason, so disable it there
+    option(TMC_COPY_COMPILE_COMMANDS "Copy compile_commands.json to the top-level build directory after each target builds" ON)
+
+    if(TMC_COPY_COMPILE_COMMANDS)
+        add_custom_command(TARGET ${target_name} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+            ${CMAKE_BINARY_DIR}/compile_commands.json
+            ${CMAKE_CURRENT_LIST_DIR}/build
+        )
+    endif()
 
     if(TMC_USE_DLL)
         target_link_libraries(${target_name} PRIVATE tmc_dll)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,11 +59,17 @@ function(make_exe_base target_name)
 
   # copy compile_commands.json to the build directory after build so clangd can find it
   # clangd won't look in the /build/{config} directory, only in the top-level /build directory
-  add_custom_command(TARGET ${target_name} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-    ${CMAKE_BINARY_DIR}/compile_commands.json
-    ${CMAKE_SOURCE_DIR}/build
-  )
+
+  # this often fails on GitHub Actions for some reason, so disable it there
+  option(TMC_COPY_COMPILE_COMMANDS "Copy compile_commands.json to the top-level build directory after each target builds" ON)
+
+  if(TMC_COPY_COMPILE_COMMANDS)
+    add_custom_command(TARGET ${target_name} POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      ${CMAKE_BINARY_DIR}/compile_commands.json
+      ${CMAKE_SOURCE_DIR}/build
+    )
+  endif()
 
   if(WIN32 AND TMC_USE_HWLOC)
     add_custom_command(TARGET ${target_name} POST_BUILD


### PR DESCRIPTION
The "copy compile_commands.json" step which is needed for clangd to detect the compilation database when there are multiple build subfolders has been a frequent source of errors in the CI pipeline. I suspect that there is a conflict when multiple parallel builds try to copy this file at the same time. This error does not occur when building locally.

This file is unneeded in CI anyway so just disable this copy.