### PR TITLE
tests and bench for qu_unbounded_mpsc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,6 +312,10 @@ make_exe(chan_bench
     examples/chan_bench.cpp
 )
 
+make_exe(qu_mpsc_bench
+    examples/qu_mpsc_bench.cpp
+)
+
 make_exe(sync
     examples/sync.cpp
 )

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Generate a coverage report for the TooManyCooks library using llvm tooling.
+#
+# Usage:
+#   ./coverage.sh                 # generate a coverage summary (lcov + report)
+#   ./coverage.sh <FILE>          # also show line-by-line coverage for <FILE>
+#                                 # (path relative to repo root or matching a
+#                                 #  source path under ./submodules/TooManyCooks)
+#
+# Configuration via environment variables:
+#   PRESET     (default: clang-linux-debug)
+#   BUILD_DIR  (default: build/coverage-${PRESET})
+#   WORK_ITEM  (default: CORO)
+#   HWLOC      (default: ON)
+#
+# Requires:
+#   llvm-profdata (any version), llvm-cov (any version), cmake, clang++.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+PRESET="${PRESET:-clang-linux-debug}"
+WORK_ITEM="${WORK_ITEM:-CORO}"
+HWLOC="${HWLOC:-ON}"
+BUILD_DIR="${BUILD_DIR:-build/coverage-${PRESET}}"
+
+# ---------------------------------------------------------------------------
+# Locate llvm tools. Prefer plain names, then the newest available numbered
+# variant (matching the local installation, which may be newer than CI's).
+# ---------------------------------------------------------------------------
+find_llvm_tool() {
+    local base="$1"
+    if command -v "$base" >/dev/null 2>&1; then
+        echo "$base"
+        return 0
+    fi
+    # Look for numbered variants llvm-cov-21, llvm-cov-20, ...
+    local found
+    found=$(compgen -c "${base}-" 2>/dev/null \
+        | grep -E "^${base}-[0-9]+$" \
+        | sort -t- -k2,2 -n -r \
+        | head -n1 || true)
+    if [[ -n "$found" ]]; then
+        echo "$found"
+        return 0
+    fi
+    return 1
+}
+
+LLVM_PROFDATA=$(find_llvm_tool llvm-profdata) || {
+    echo "ERROR: llvm-profdata not found. Install llvm tooling and try again." >&2
+    exit 1
+}
+LLVM_COV=$(find_llvm_tool llvm-cov) || {
+    echo "ERROR: llvm-cov not found. Install llvm tooling and try again." >&2
+    exit 1
+}
+echo "Using: $LLVM_PROFDATA"
+echo "Using: $LLVM_COV"
+
+# ---------------------------------------------------------------------------
+# Configure + build with coverage instrumentation.
+# ---------------------------------------------------------------------------
+COV_FLAGS="-fprofile-instr-generate;-fcoverage-mapping"
+EXTRA_OPTS=()
+if [[ "$WORK_ITEM" == "FUNC" ]]; then
+    EXTRA_OPTS+=("-DTMC_TRIVIAL_TASK=ON")
+fi
+
+cmake \
+    -DTMC_AS_SUBMODULE=ON \
+    -DTMC_COPY_COMPILE_COMMANDS=OFF \
+    -DTMC_USE_HWLOC="${HWLOC}" \
+    -DTMC_WORK_ITEM="${WORK_ITEM}" \
+    "${EXTRA_OPTS[@]}" \
+    -DCMD_COMPILE_FLAGS="-Werror;${COV_FLAGS}" \
+    -DCMD_LINK_FLAGS="-Wl,--build-id;${COV_FLAGS}" \
+    -B "${BUILD_DIR}" \
+    --preset "${PRESET}" \
+    .
+
+cmake --build "${BUILD_DIR}" \
+    --parallel "$(nproc)" \
+    --target tests test_exceptions test_fuzz_chan
+
+# ---------------------------------------------------------------------------
+# Run tests and merge raw profiles.
+# ---------------------------------------------------------------------------
+PROF_DIR="${BUILD_DIR}/coverage-profiles"
+rm -rf "${PROF_DIR}"
+mkdir -p "${PROF_DIR}"
+
+LLVM_PROFILE_FILE="${PROF_DIR}/tests.profraw" \
+    "${BUILD_DIR}/tests/tests"
+LLVM_PROFILE_FILE="${PROF_DIR}/test_exceptions.profraw" \
+    "${BUILD_DIR}/tests/test_exceptions"
+LLVM_PROFILE_FILE="${PROF_DIR}/test_fuzz_chan.profraw" \
+    "${BUILD_DIR}/tests/test_fuzz_chan"
+
+"${LLVM_PROFDATA}" merge \
+    -o "${PROF_DIR}/coverage.profdata" \
+    "${PROF_DIR}/tests.profraw" \
+    "${PROF_DIR}/test_exceptions.profraw" \
+    "${PROF_DIR}/test_fuzz_chan.profraw"
+
+# ---------------------------------------------------------------------------
+# Emit reports. Always produce an lcov file scoped to TooManyCooks sources;
+# optionally show line-by-line coverage for a specific file.
+# ---------------------------------------------------------------------------
+LCOV_FILE="${BUILD_DIR}/coverage.lcov"
+"${LLVM_COV}" export \
+    -format=lcov \
+    -instr-profile "${PROF_DIR}/coverage.profdata" \
+    -object "${BUILD_DIR}/tests/tests" \
+    -object "${BUILD_DIR}/tests/test_exceptions" \
+    -object "${BUILD_DIR}/tests/test_fuzz_chan" \
+    -sources ./submodules/TooManyCooks/ \
+    > "${LCOV_FILE}"
+echo "Wrote lcov coverage to ${LCOV_FILE}"
+
+echo
+echo "===== Coverage summary (TooManyCooks sources) ====="
+"${LLVM_COV}" report \
+    -instr-profile "${PROF_DIR}/coverage.profdata" \
+    -object "${BUILD_DIR}/tests/tests" \
+    -object "${BUILD_DIR}/tests/test_exceptions" \
+    -object "${BUILD_DIR}/tests/test_fuzz_chan" \
+    -sources ./submodules/TooManyCooks/
+
+if [[ $# -ge 1 ]]; then
+    TARGET_FILE="$1"
+    if [[ ! -f "${TARGET_FILE}" ]]; then
+        # Try resolving relative to the TMC submodule include path.
+        for candidate in \
+            "submodules/TooManyCooks/${TARGET_FILE}" \
+            "submodules/TooManyCooks/include/${TARGET_FILE}" \
+            "submodules/TooManyCooks/include/tmc/${TARGET_FILE}"
+        do
+            if [[ -f "${candidate}" ]]; then
+                TARGET_FILE="${candidate}"
+                break
+            fi
+        done
+    fi
+    if [[ ! -f "${TARGET_FILE}" ]]; then
+        echo "ERROR: source file '$1' not found." >&2
+        exit 1
+    fi
+
+    ABS_TARGET="$(realpath "${TARGET_FILE}")"
+    OUT_FILE="${BUILD_DIR}/coverage-$(basename "${TARGET_FILE}").txt"
+
+    echo
+    echo "===== Line-by-line coverage for ${TARGET_FILE} ====="
+    "${LLVM_COV}" show \
+        -instr-profile "${PROF_DIR}/coverage.profdata" \
+        -object "${BUILD_DIR}/tests/tests" \
+        -object "${BUILD_DIR}/tests/test_exceptions" \
+        -object "${BUILD_DIR}/tests/test_fuzz_chan" \
+        -show-line-counts-or-regions \
+        -use-color=false \
+        -sources "${ABS_TARGET}" \
+        > "${OUT_FILE}"
+    cat "${OUT_FILE}"
+    echo
+    echo "Wrote line-by-line coverage to ${OUT_FILE}"
+fi

--- a/examples/qu_mpsc_bench.cpp
+++ b/examples/qu_mpsc_bench.cpp
@@ -13,14 +13,14 @@
 #include <vector>
 
 #define NELEMS 10000000
-static constexpr size_t PRODUCER_COUNT = 2;
+static constexpr size_t PRODUCER_COUNT = 1;
 static constexpr size_t CONSUMER_COUNT = 1;
 
 struct queue_config : tmc::qu_unbounded_mpsc_default_config {
-  static inline constexpr bool ConsumerCanSuspend = true;
-  // static inline constexpr size_t BlockSize = 4096;
-  // static inline constexpr size_t PackingLevel = 0;
-  // static inline constexpr bool EmbedFirstBlock = false;
+  // static inline constexpr bool ConsumerCanSuspend = true;
+  //  static inline constexpr size_t BlockSize = 4096;
+  //  static inline constexpr size_t PackingLevel = 0;
+  //  static inline constexpr bool EmbedFirstBlock = false;
 };
 using queue_t = tmc::qu_unbounded_mpsc<size_t, queue_config>;
 
@@ -35,9 +35,9 @@ producer(queue_t& queue, size_t count, size_t base) {
   // but for this benchmark we test pushing 1 at a time.
   for (size_t i = 0; i < count; ++i) {
     queue.post(base + i);
-    // if (i % 16384 == 0) {
-    //   co_await tmc::reschedule();
-    // }
+    if (i % 16384 == 0) {
+      co_await tmc::reschedule();
+    }
   }
   auto endTime = std::chrono::high_resolution_clock::now();
   co_return producer_result{static_cast<size_t>(
@@ -118,7 +118,7 @@ int main() {
     }
     auto startTime = std::chrono::high_resolution_clock::now();
     std::vector<tmc::task<result>> cons(CONSUMER_COUNT);
-    cons[0] = consumer(queue, NELEMS);
+    cons[0] = consumer_try_pull(queue, NELEMS);
     auto c = tmc::spawn_many(cons).fork();
     auto prodResults = co_await tmc::spawn_many(prod);
     auto consResults = co_await std::move(c);

--- a/examples/qu_mpsc_bench.cpp
+++ b/examples/qu_mpsc_bench.cpp
@@ -1,0 +1,182 @@
+// A benchmark for the throughput of tmc::qu_unbounded_mpsc in SPSC mode.
+
+#include "tmc/all_headers.hpp"
+#include "tmc/aw_yield.hpp"
+#include "tmc/qu_unbounded_mpsc.hpp"
+#include "tmc/topology.hpp"
+
+#include <cassert>
+#include <chrono>
+#include <cstdio>
+#include <string>
+#include <utility>
+#include <vector>
+
+#define NELEMS 10000000
+static constexpr size_t PRODUCER_COUNT = 2;
+static constexpr size_t CONSUMER_COUNT = 1;
+
+struct queue_config : tmc::qu_unbounded_mpsc_default_config {
+  static inline constexpr bool ConsumerCanSuspend = true;
+  // static inline constexpr size_t BlockSize = 4096;
+  // static inline constexpr size_t PackingLevel = 0;
+  // static inline constexpr bool EmbedFirstBlock = false;
+};
+using queue_t = tmc::qu_unbounded_mpsc<size_t, queue_config>;
+
+struct producer_result {
+  size_t duration_us;
+};
+
+static tmc::task<producer_result>
+producer(queue_t& queue, size_t count, size_t base) {
+  auto startTime = std::chrono::high_resolution_clock::now();
+  // It would be more efficient to call `queue.post_bulk()`,
+  // but for this benchmark we test pushing 1 at a time.
+  for (size_t i = 0; i < count; ++i) {
+    queue.post(base + i);
+    // if (i % 16384 == 0) {
+    //   co_await tmc::reschedule();
+    // }
+  }
+  auto endTime = std::chrono::high_resolution_clock::now();
+  co_return producer_result{static_cast<size_t>(
+    std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime)
+      .count()
+  )};
+}
+
+struct result {
+  size_t count;
+  size_t sum;
+};
+
+static tmc::task<result> consumer(queue_t& queue, size_t expected_count) {
+  size_t count = 0;
+  size_t sum = 0;
+
+  while (count < expected_count) {
+    auto data = co_await queue.pull();
+    ++count;
+    sum += *data;
+  }
+
+  co_return result{count, sum};
+}
+
+[[maybe_unused]] static tmc::task<result>
+consumer_try_pull(queue_t& queue, size_t expected_count) {
+  size_t count = 0;
+  size_t sum = 0;
+
+  while (count < expected_count) {
+    auto data = queue.try_pull();
+    if (data) {
+      ++count;
+      sum += *data;
+    } else {
+      co_await tmc::reschedule();
+    }
+  }
+
+  co_return result{count, sum};
+}
+
+static std::string formatWithCommas(size_t n) {
+  auto s = std::to_string(n);
+  int i = static_cast<int>(s.length()) - 3;
+  while (i > 0) {
+    s.insert(static_cast<size_t>(i), ",");
+    i -= 3;
+  }
+  return s;
+}
+
+int main() {
+#ifdef TMC_USE_HWLOC
+  tmc::topology::topology_filter f;
+  f.set_group_indexes({0});
+  tmc::cpu_executor().add_partition(f);
+#endif
+  tmc::cpu_executor().init();
+  std::printf(
+    "qu_mpsc SPSC bench: %zu threads | %s elements\n",
+    tmc::cpu_executor().thread_count(), formatWithCommas(NELEMS).c_str()
+  );
+  return tmc::async_main([]() -> tmc::task<int> {
+    auto overallStart = std::chrono::high_resolution_clock::now();
+
+    queue_t queue;
+    size_t per_task = NELEMS / PRODUCER_COUNT;
+    size_t rem = NELEMS % PRODUCER_COUNT;
+    std::vector<tmc::task<producer_result>> prod(PRODUCER_COUNT);
+    size_t base = 0;
+    for (size_t i = 0; i < PRODUCER_COUNT; ++i) {
+      size_t count = i < rem ? per_task + 1 : per_task;
+      prod[i] = producer(queue, count, base);
+      base += count;
+    }
+    auto startTime = std::chrono::high_resolution_clock::now();
+    std::vector<tmc::task<result>> cons(CONSUMER_COUNT);
+    cons[0] = consumer(queue, NELEMS);
+    auto c = tmc::spawn_many(cons).fork();
+    auto prodResults = co_await tmc::spawn_many(prod);
+    auto consResults = co_await std::move(c);
+
+    auto endTime = std::chrono::high_resolution_clock::now();
+
+    size_t count = 0;
+    size_t sum = 0;
+    for (size_t i = 0; i < consResults.size(); ++i) {
+      count += consResults[i].count;
+      sum += consResults[i].sum;
+    }
+    if (count != NELEMS) {
+      std::printf(
+        "FAIL: Expected %zu elements but consumed %zu elements\n",
+        static_cast<size_t>(NELEMS), count
+      );
+    }
+
+    size_t expectedSum = 0;
+    for (size_t i = 0; i < NELEMS; ++i) {
+      expectedSum += i;
+    }
+    if (sum != expectedSum) {
+      std::printf("FAIL: Expected %zu sum but got %zu sum\n", expectedSum, sum);
+    }
+    size_t maxProducerDuration = 0;
+    for (size_t i = 0; i < prodResults.size(); ++i) {
+      if (maxProducerDuration < prodResults[i].duration_us) {
+        maxProducerDuration = prodResults[i].duration_us;
+      }
+    }
+
+    size_t execDur = static_cast<size_t>(
+      std::chrono::duration_cast<std::chrono::microseconds>(endTime - startTime)
+        .count()
+    );
+
+    double durMs = static_cast<double>(execDur) / 1000.0;
+    size_t elementsPerSec =
+      static_cast<size_t>(static_cast<double>(NELEMS) * 1000.0 / durMs);
+    std::printf(
+      "%zu prod\t%zu cons\t %.2f ms\t%s elements/sec\n", PRODUCER_COUNT,
+      CONSUMER_COUNT, durMs, formatWithCommas(elementsPerSec).c_str()
+    );
+    std::printf(
+      "producer max: %.2f ms\n",
+      static_cast<double>(maxProducerDuration) / 1000.0
+    );
+
+    auto overallEnd = std::chrono::high_resolution_clock::now();
+    size_t overallDur =
+      static_cast<size_t>(std::chrono::duration_cast<std::chrono::microseconds>(
+                            overallEnd - overallStart
+      )
+                            .count());
+    double overallSec = static_cast<double>(overallDur) / 1000000.0;
+    std::printf("overall: %.2f sec\n", overallSec);
+    co_return 0;
+  }());
+}

--- a/examples/qu_mpsc_bench.cpp
+++ b/examples/qu_mpsc_bench.cpp
@@ -13,11 +13,11 @@
 #include <vector>
 
 #define NELEMS 10000000
-static constexpr size_t PRODUCER_COUNT = 1;
+static constexpr size_t PRODUCER_COUNT = 2;
 static constexpr size_t CONSUMER_COUNT = 1;
 
 struct queue_config : tmc::qu_unbounded_mpsc_default_config {
-  // static inline constexpr bool ConsumerCanSuspend = true;
+  //  static inline constexpr bool ConsumerCanSuspend = true;
   //  static inline constexpr size_t BlockSize = 4096;
   //  static inline constexpr size_t PackingLevel = 0;
   //  static inline constexpr bool EmbedFirstBlock = false;
@@ -51,7 +51,8 @@ struct result {
   size_t sum;
 };
 
-static tmc::task<result> consumer(queue_t& queue, size_t expected_count) {
+[[maybe_unused]] static tmc::task<result>
+consumer(queue_t& queue, size_t expected_count) {
   size_t count = 0;
   size_t sum = 0;
 
@@ -118,7 +119,7 @@ int main() {
     }
     auto startTime = std::chrono::high_resolution_clock::now();
     std::vector<tmc::task<result>> cons(CONSUMER_COUNT);
-    cons[0] = consumer_try_pull(queue, NELEMS);
+    cons[0] = consumer(queue, NELEMS);
     auto c = tmc::spawn_many(cons).fork();
     auto prodResults = co_await tmc::spawn_many(prod);
     auto consResults = co_await std::move(c);

--- a/tests/test_qu_mpsc.cpp
+++ b/tests/test_qu_mpsc.cpp
@@ -19,8 +19,7 @@ protected:
 
 static constexpr size_t MPSC_TEST_SENTINEL = static_cast<size_t>(-1);
 
-template <size_t Pack>
-struct chan_config : tmc::qu_unbounded_mpsc_default_config {
+template <size_t Pack> struct q_config : tmc::qu_unbounded_mpsc_default_config {
   // Use a small block size to ensure that alloc / reclaim is triggered.
   static inline constexpr size_t BlockSize = 2;
   static inline constexpr size_t PackingLevel = Pack;
@@ -55,7 +54,7 @@ struct mpsc_destructor_counter {
 
 // multiple tests in one to leverage the configuration options in one place
 template <size_t PackingLevel, typename Executor>
-void do_chan_test(Executor& Exec) {
+void do_q_test(Executor& Exec) {
   test_async_main(Exec, []() -> tmc::task<void> {
     {
       // general test - single push
@@ -65,29 +64,29 @@ void do_chan_test(Executor& Exec) {
         size_t sum;
       };
 
-      auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<PackingLevel>>{};
+      auto q = tmc::qu_unbounded_mpsc<size_t, q_config<PackingLevel>>{};
 
       auto results = co_await tmc::spawn_tuple(
-        [](auto& Chan) -> tmc::task<size_t> {
+        [](auto& Q) -> tmc::task<size_t> {
           size_t i = 0;
           for (; i < NITEMS; ++i) {
-            Chan.post(i);
+            Q.post(i);
           }
-          Chan.post(MPSC_TEST_SENTINEL);
+          Q.post(MPSC_TEST_SENTINEL);
           co_return i;
-        }(chan),
-        [](auto& Chan) -> tmc::task<result> {
+        }(q),
+        [](auto& Q) -> tmc::task<result> {
           size_t count = 0;
           size_t sum = 0;
           while (true) {
-            auto v = co_await Chan.pull();
+            auto v = co_await Q.pull();
             if (*v == MPSC_TEST_SENTINEL) {
               co_return result{count, sum};
             }
             ++count;
             sum += *v;
           }
-        }(chan)
+        }(q)
       );
       auto& prod = std::get<0>(results);
       auto& cons = std::get<1>(results);
@@ -107,34 +106,34 @@ void do_chan_test(Executor& Exec) {
         size_t sum;
       };
 
-      auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<PackingLevel>>{};
+      auto q = tmc::qu_unbounded_mpsc<size_t, q_config<PackingLevel>>{};
 
       auto results = co_await tmc::spawn_tuple(
-        [](auto& Chan) -> tmc::task<size_t> {
+        [](auto& Q) -> tmc::task<size_t> {
           size_t i = 0;
           for (; i < NITEMS; i += (NITEMS / 10)) {
             size_t j = i + (NITEMS / 10);
             if (j > NITEMS) {
               j = NITEMS;
             }
-            Chan.post_bulk(std::ranges::views::iota(i).begin(), j - i);
+            Q.post_bulk(std::ranges::views::iota(i).begin(), j - i);
           }
           co_return i;
-        }(chan),
-        [](auto& Chan) -> tmc::task<result> {
+        }(q),
+        [](auto& Q) -> tmc::task<result> {
           size_t count = 0;
           size_t sum = 0;
           for (size_t i = 0; i < NITEMS; ++i) {
-            auto v = Chan.try_pull();
+            auto v = Q.try_pull();
             while (!v) {
               TMC_CPU_PAUSE();
-              v = Chan.try_pull();
+              v = Q.try_pull();
             }
             ++count;
             sum += *v;
           }
           co_return result{count, sum};
-        }(chan)
+        }(q)
       );
       auto& prod = std::get<0>(results);
       auto& cons = std::get<1>(results);
@@ -147,31 +146,31 @@ void do_chan_test(Executor& Exec) {
       EXPECT_EQ(expectedSum, cons.sum);
     }
     {
-      // destroy chan with data remaining inside
+      // destroy q with data remaining inside
       std::atomic<size_t> count;
       {
-        auto chan = tmc::qu_unbounded_mpsc<
-          mpsc_destructor_counter, chan_config<PackingLevel>>{};
+        auto q = tmc::qu_unbounded_mpsc<
+          mpsc_destructor_counter, q_config<PackingLevel>>{};
         for (size_t i = 0; i < 12; ++i) {
-          chan.post(mpsc_destructor_counter{&count});
+          q.post(mpsc_destructor_counter{&count});
         }
 
         for (size_t i = 0; i < 7; ++i) {
-          auto ok = chan.try_pull();
+          auto ok = q.try_pull();
           EXPECT_TRUE(static_cast<bool>(ok));
         }
 
         EXPECT_EQ(count.load(), 7);
       }
-      // Now chan goes out of scope; remaining data's destructors are called
+      // Now q goes out of scope; remaining data's destructors are called
       EXPECT_EQ(count.load(), 12);
     }
   }());
 }
 
 TEST_F(CATEGORY, config_sweep) {
-  do_chan_test<0>(ex());
-  do_chan_test<1>(ex());
+  do_q_test<0>(ex());
+  do_q_test<1>(ex());
 }
 
 // Test post_bulk of 0 items
@@ -179,22 +178,22 @@ TEST_F(CATEGORY, post_bulk_none) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
     size_t i = 0;
     for (; i < 4; ++i) {
-      chan.post_bulk(&i, 0);
-      chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
-      chan.post(i);
+      q.post_bulk(&i, 0);
+      q.post_bulk(std::ranges::views::iota(i).begin(), 0);
+      q.post(i);
     }
     for (; i < 8; ++i) {
-      chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
-      chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
-      chan.post_bulk(std::ranges::views::iota(i).begin(), 1);
+      q.post_bulk(std::ranges::views::iota(i).begin(), 0);
+      q.post_bulk(std::ranges::views::iota(i).begin(), 0);
+      q.post_bulk(std::ranges::views::iota(i).begin(), 1);
     }
     size_t count = 0;
     size_t sum = 0;
     for (size_t j = 0; j < i; ++j) {
-      auto v = chan.try_pull();
+      auto v = q.try_pull();
       EXPECT_TRUE(static_cast<bool>(v));
       sum += *v;
       ++count;
@@ -202,7 +201,7 @@ TEST_F(CATEGORY, post_bulk_none) {
     EXPECT_EQ(28, sum);
     EXPECT_EQ(8, count);
 
-    auto v = chan.try_pull();
+    auto v = q.try_pull();
     EXPECT_FALSE(static_cast<bool>(v));
     co_return;
   }());
@@ -212,22 +211,22 @@ TEST_F(CATEGORY, post_bulk_none) {
 TEST_F(CATEGORY, close_basic_try_pull) {
   test_async_main(ex(), []() -> tmc::task<void> {
     using qerr = tmc::qu_unbounded_mpsc_err;
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
 
     for (size_t i = 0; i < 5; ++i) {
-      EXPECT_TRUE(chan.post(i));
+      EXPECT_TRUE(q.post(i));
     }
 
-    chan.close();
+    q.close();
 
     // post() after close should fail.
-    EXPECT_FALSE(chan.post(static_cast<size_t>(99)));
+    EXPECT_FALSE(q.post(static_cast<size_t>(99)));
 
     // Drain the queue.
     size_t sum = 0;
     size_t count = 0;
     while (true) {
-      auto v = chan.try_pull();
+      auto v = q.try_pull();
       if (v.status() == qerr::OK) {
         sum += *v;
         ++count;
@@ -243,7 +242,7 @@ TEST_F(CATEGORY, close_basic_try_pull) {
     EXPECT_EQ(0u + 1u + 2u + 3u + 4u, sum);
 
     // Further try_pull stays CLOSED.
-    auto v = chan.try_pull();
+    auto v = q.try_pull();
     EXPECT_EQ(qerr::CLOSED, v.status());
     EXPECT_FALSE(static_cast<bool>(v));
     co_return;
@@ -254,10 +253,10 @@ TEST_F(CATEGORY, close_basic_try_pull) {
 TEST_F(CATEGORY, close_empty_try_pull) {
   test_async_main(ex(), []() -> tmc::task<void> {
     using qerr = tmc::qu_unbounded_mpsc_err;
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
-    chan.close();
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    q.close();
 
-    auto v = chan.try_pull();
+    auto v = q.try_pull();
     EXPECT_EQ(qerr::CLOSED, v.status());
     EXPECT_FALSE(static_cast<bool>(v));
     co_return;
@@ -267,11 +266,11 @@ TEST_F(CATEGORY, close_empty_try_pull) {
 // close() is idempotent.
 TEST_F(CATEGORY, close_idempotent) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
-    chan.close();
-    chan.close();
-    chan.close();
-    EXPECT_FALSE(chan.post(static_cast<size_t>(1)));
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    q.close();
+    q.close();
+    q.close();
+    EXPECT_FALSE(q.post(static_cast<size_t>(1)));
     co_return;
   }());
 }
@@ -279,18 +278,18 @@ TEST_F(CATEGORY, close_idempotent) {
 // pull() resumes with an empty scope when the queue is closed and drained.
 TEST_F(CATEGORY, close_pull_drains_then_returns_empty) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
 
     for (size_t i = 0; i < 3; ++i) {
-      EXPECT_TRUE(chan.post(i));
+      EXPECT_TRUE(q.post(i));
     }
-    chan.close();
+    q.close();
 
     // Drain via pull().
     size_t count = 0;
     size_t sum = 0;
     while (true) {
-      auto v = co_await chan.pull();
+      auto v = co_await q.pull();
       if (!v) {
         break; // closed and drained
       }
@@ -308,21 +307,21 @@ TEST_F(CATEGORY, close_pull_drains_then_returns_empty) {
 // CLOSED sentinel at slot 0, which wakes the consumer with an empty scope.
 TEST_F(CATEGORY, close_wakes_suspended_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
 
     auto results = co_await tmc::spawn_tuple(
-      [](auto& Chan) -> tmc::task<bool> {
-        auto v = co_await Chan.pull();
+      [](auto& Q) -> tmc::task<bool> {
+        auto v = co_await Q.pull();
         co_return static_cast<bool>(v);
-      }(chan),
-      [](auto& Chan) -> tmc::task<void> {
-        // Yield to give the consumer a chance to suspend.
+      }(q),
+      [](auto& Q) -> tmc::task<void> {
+        // Yield to give the consumer a qce to suspend.
         for (size_t i = 0; i < 10; ++i) {
           co_await tmc::reschedule();
         }
-        Chan.close();
+        Q.close();
         co_return;
-      }(chan)
+      }(q)
     );
 
     bool got_value = std::get<0>(results);
@@ -334,11 +333,11 @@ TEST_F(CATEGORY, close_wakes_suspended_consumer) {
 // post_bulk() returns false when called after close.
 TEST_F(CATEGORY, close_post_bulk_returns_false) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
-    chan.close();
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    q.close();
 
     size_t vals[3] = {10, 11, 12};
-    EXPECT_FALSE(chan.post_bulk(&vals[0], 3));
+    EXPECT_FALSE(q.post_bulk(&vals[0], 3));
     co_return;
   }());
 }
@@ -348,13 +347,13 @@ TEST_F(CATEGORY, close_post_bulk_returns_false) {
 TEST_F(CATEGORY, close_concurrent_producer) {
   test_async_main(ex(), []() -> tmc::task<void> {
     static constexpr size_t NITEMS = 2000;
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
     std::atomic<size_t> posted_ok{0};
 
     auto results = co_await tmc::spawn_tuple(
-      [&](auto& Chan) -> tmc::task<void> {
+      [&](auto& Q) -> tmc::task<void> {
         for (size_t i = 0; i < NITEMS; ++i) {
-          if (Chan.post(static_cast<size_t>(1))) {
+          if (Q.post(static_cast<size_t>(1))) {
             posted_ok.fetch_add(1, std::memory_order_relaxed);
           }
           // Yield occasionally to allow other tasks to run.
@@ -364,21 +363,21 @@ TEST_F(CATEGORY, close_concurrent_producer) {
         }
         // After this producer is done, close the queue. There are no other
         // producers, so all posts() that succeeded are pre-close.
-        Chan.close();
+        Q.close();
         // Subsequent posts must fail.
-        EXPECT_FALSE(Chan.post(static_cast<size_t>(999)));
+        EXPECT_FALSE(Q.post(static_cast<size_t>(999)));
         co_return;
-      }(chan),
-      [](auto& Chan) -> tmc::task<size_t> {
+      }(q),
+      [](auto& Q) -> tmc::task<size_t> {
         size_t pulled = 0;
         while (true) {
-          auto v = co_await Chan.pull();
+          auto v = co_await Q.pull();
           if (!v) {
             co_return pulled;
           }
           pulled += *v;
         }
-      }(chan)
+      }(q)
     );
 
     size_t pulled = std::get<1>(results);
@@ -393,22 +392,22 @@ TEST_F(CATEGORY, close_concurrent_producer) {
 TEST_F(CATEGORY, close_inline_basic_try_pull) {
   test_async_main(ex(), []() -> tmc::task<void> {
     using qerr = tmc::qu_unbounded_mpsc_err;
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
 
     for (size_t i = 0; i < 5; ++i) {
-      EXPECT_TRUE(chan.post(i));
+      EXPECT_TRUE(q.post(i));
     }
 
-    chan.close_inline();
+    q.close_inline();
 
     // post() after close_inline should fail.
-    EXPECT_FALSE(chan.post(static_cast<size_t>(99)));
+    EXPECT_FALSE(q.post(static_cast<size_t>(99)));
 
     // Drain the queue.
     size_t sum = 0;
     size_t count = 0;
     while (true) {
-      auto v = chan.try_pull();
+      auto v = q.try_pull();
       if (v.status() == qerr::OK) {
         sum += *v;
         ++count;
@@ -423,7 +422,7 @@ TEST_F(CATEGORY, close_inline_basic_try_pull) {
     EXPECT_EQ(0u + 1u + 2u + 3u + 4u, sum);
 
     // Further try_pull stays CLOSED.
-    auto v = chan.try_pull();
+    auto v = q.try_pull();
     EXPECT_EQ(qerr::CLOSED, v.status());
     EXPECT_FALSE(static_cast<bool>(v));
     co_return;
@@ -434,10 +433,10 @@ TEST_F(CATEGORY, close_inline_basic_try_pull) {
 TEST_F(CATEGORY, close_inline_empty_try_pull) {
   test_async_main(ex(), []() -> tmc::task<void> {
     using qerr = tmc::qu_unbounded_mpsc_err;
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
-    chan.close_inline();
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    q.close_inline();
 
-    auto v = chan.try_pull();
+    auto v = q.try_pull();
     EXPECT_EQ(qerr::CLOSED, v.status());
     EXPECT_FALSE(static_cast<bool>(v));
     co_return;
@@ -447,12 +446,12 @@ TEST_F(CATEGORY, close_inline_empty_try_pull) {
 // close_inline() is idempotent and may be intermixed with close().
 TEST_F(CATEGORY, close_inline_idempotent) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
-    chan.close_inline();
-    chan.close_inline();
-    chan.close();
-    chan.close_inline();
-    EXPECT_FALSE(chan.post(static_cast<size_t>(1)));
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    q.close_inline();
+    q.close_inline();
+    q.close();
+    q.close_inline();
+    EXPECT_FALSE(q.post(static_cast<size_t>(1)));
     co_return;
   }());
 }
@@ -461,18 +460,18 @@ TEST_F(CATEGORY, close_inline_idempotent) {
 // drained.
 TEST_F(CATEGORY, close_inline_pull_drains_then_returns_empty) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
 
     for (size_t i = 0; i < 3; ++i) {
-      EXPECT_TRUE(chan.post(i));
+      EXPECT_TRUE(q.post(i));
     }
-    chan.close_inline();
+    q.close_inline();
 
     // Drain via pull().
     size_t count = 0;
     size_t sum = 0;
     while (true) {
-      auto v = co_await chan.pull();
+      auto v = co_await q.pull();
       if (!v) {
         break; // closed and drained
       }
@@ -491,21 +490,21 @@ TEST_F(CATEGORY, close_inline_pull_drains_then_returns_empty) {
 // which wakes the consumer with an empty scope.
 TEST_F(CATEGORY, close_inline_wakes_suspended_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
 
     auto results = co_await tmc::spawn_tuple(
-      [](auto& Chan) -> tmc::task<bool> {
-        auto v = co_await Chan.pull();
+      [](auto& Q) -> tmc::task<bool> {
+        auto v = co_await Q.pull();
         co_return static_cast<bool>(v);
-      }(chan),
-      [](auto& Chan) -> tmc::task<void> {
-        // Yield to give the consumer a chance to suspend.
+      }(q),
+      [](auto& Q) -> tmc::task<void> {
+        // Yield to give the consumer a qce to suspend.
         for (size_t i = 0; i < 10; ++i) {
           co_await tmc::reschedule();
         }
-        Chan.close_inline();
+        Q.close_inline();
         co_return;
-      }(chan)
+      }(q)
     );
 
     bool got_value = std::get<0>(results);
@@ -516,8 +515,8 @@ TEST_F(CATEGORY, close_inline_wakes_suspended_consumer) {
 
 // Config that uses the default ConsumerCanSuspend = false. This exercises
 // the non-suspending code path in write_element (set_data_ready()), which
-// chan_config<> overrides to true and which is otherwise never tested.
-struct chan_config_no_suspend : tmc::qu_unbounded_mpsc_default_config {
+// q_config<> overrides to true and which is otherwise never tested.
+struct q_config_no_suspend : tmc::qu_unbounded_mpsc_default_config {
   static inline constexpr size_t BlockSize = 2;
   // ConsumerCanSuspend defaults to false
 };
@@ -525,24 +524,24 @@ struct chan_config_no_suspend : tmc::qu_unbounded_mpsc_default_config {
 TEST_F(CATEGORY, no_suspend_try_pull_only) {
   test_async_main(ex(), []() -> tmc::task<void> {
     using qerr = tmc::qu_unbounded_mpsc_err;
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config_no_suspend>{};
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config_no_suspend>{};
 
     // No data available yet: try_pull returns EMPTY.
     {
-      auto v = chan.try_pull();
+      auto v = q.try_pull();
       EXPECT_EQ(qerr::EMPTY, v.status());
       EXPECT_FALSE(static_cast<bool>(v));
     }
 
     static constexpr size_t NITEMS = 100;
     for (size_t i = 0; i < NITEMS; ++i) {
-      EXPECT_TRUE(chan.post(i));
+      EXPECT_TRUE(q.post(i));
     }
 
     size_t sum = 0;
     size_t count = 0;
     for (size_t i = 0; i < NITEMS; ++i) {
-      auto v = chan.try_pull();
+      auto v = q.try_pull();
       EXPECT_EQ(qerr::OK, v.status());
       EXPECT_TRUE(static_cast<bool>(v));
       sum += *v;
@@ -556,13 +555,13 @@ TEST_F(CATEGORY, no_suspend_try_pull_only) {
     EXPECT_EQ(expected, sum);
 
     // After draining: EMPTY again.
-    auto v = chan.try_pull();
+    auto v = q.try_pull();
     EXPECT_EQ(qerr::EMPTY, v.status());
     EXPECT_FALSE(static_cast<bool>(v));
 
     // Close and verify CLOSED status.
-    chan.close();
-    auto v2 = chan.try_pull();
+    q.close();
+    auto v2 = q.try_pull();
     EXPECT_EQ(qerr::CLOSED, v2.status());
     co_return;
   }());
@@ -571,7 +570,7 @@ TEST_F(CATEGORY, no_suspend_try_pull_only) {
 // EmbedFirstBlock = true: first block is embedded in the qu_mpsc object.
 // Push and reclaim past the embedded block to ensure the destructor handles
 // the embedded-vs-heap distinction correctly.
-struct chan_config_embed : tmc::qu_unbounded_mpsc_default_config {
+struct q_config_embed : tmc::qu_unbounded_mpsc_default_config {
   static inline constexpr size_t BlockSize = 2;
   static inline constexpr bool EmbedFirstBlock = true;
   static inline constexpr bool ConsumerCanSuspend = true;
@@ -579,12 +578,12 @@ struct chan_config_embed : tmc::qu_unbounded_mpsc_default_config {
 
 TEST_F(CATEGORY, embed_first_block) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config_embed>{};
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config_embed>{};
     static constexpr size_t NITEMS = 50; // many block transitions
     size_t sum = 0;
     for (size_t i = 0; i < NITEMS; ++i) {
-      EXPECT_TRUE(chan.post(i));
-      auto v = chan.try_pull();
+      EXPECT_TRUE(q.post(i));
+      auto v = q.try_pull();
       EXPECT_TRUE(static_cast<bool>(v));
       sum += *v;
     }
@@ -601,12 +600,12 @@ TEST_F(CATEGORY, embed_first_block) {
   {
     std::atomic<size_t> count{0};
     {
-      auto chan =
-        tmc::qu_unbounded_mpsc<mpsc_destructor_counter, chan_config_embed>{};
+      auto q =
+        tmc::qu_unbounded_mpsc<mpsc_destructor_counter, q_config_embed>{};
       // 2 items fit in the embedded block (BlockSize=2). Add more to also
       // exercise heap blocks alongside the embedded block.
       for (size_t i = 0; i < 5; ++i) {
-        chan.post(mpsc_destructor_counter{&count});
+        q.post(mpsc_destructor_counter{&count});
       }
     }
     EXPECT_EQ(count.load(), 5);
@@ -621,10 +620,10 @@ TEST_F(CATEGORY, multi_producer) {
     static constexpr size_t PER_PRODUCER = 500;
     static constexpr size_t TOTAL = NPRODUCERS * PER_PRODUCER;
 
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
 
     auto results = co_await tmc::spawn_tuple(
-      [](auto& Chan) -> tmc::task<size_t> {
+      [](auto& Q) -> tmc::task<size_t> {
         // Producer orchestrator: spawn NPRODUCERS producers in parallel.
         std::vector<tmc::task<size_t>> producers;
         for (size_t p = 0; p < NPRODUCERS; ++p) {
@@ -638,7 +637,7 @@ TEST_F(CATEGORY, multi_producer) {
               }
             }
             co_return produced;
-          }(Chan, p * PER_PRODUCER));
+          }(Q, p * PER_PRODUCER));
         }
         auto counts =
           co_await tmc::spawn_many(producers.data(), producers.size());
@@ -647,13 +646,13 @@ TEST_F(CATEGORY, multi_producer) {
           totalProduced += c;
         }
         // Wake the consumer.
-        Chan.post(MPSC_TEST_SENTINEL);
+        Q.post(MPSC_TEST_SENTINEL);
         co_return totalProduced;
-      }(chan),
-      [](auto& Chan) -> tmc::task<size_t> {
+      }(q),
+      [](auto& Q) -> tmc::task<size_t> {
         size_t pulled = 0;
         while (true) {
-          auto v = co_await Chan.pull();
+          auto v = co_await Q.pull();
           if (!v) {
             co_return pulled;
           }
@@ -662,7 +661,7 @@ TEST_F(CATEGORY, multi_producer) {
           }
           ++pulled;
         }
-      }(chan)
+      }(q)
     );
 
     EXPECT_EQ(TOTAL, std::get<0>(results));
@@ -680,13 +679,12 @@ TEST_F(CATEGORY, try_pull_zc_scope_move) {
     {
       std::atomic<size_t> count{0};
       {
-        auto chan =
-          tmc::qu_unbounded_mpsc<mpsc_destructor_counter, chan_config<0>>{};
-        chan.post(mpsc_destructor_counter{&count});
-        chan.post(mpsc_destructor_counter{&count});
-        chan.post(mpsc_destructor_counter{&count});
+        auto q = tmc::qu_unbounded_mpsc<mpsc_destructor_counter, q_config<0>>{};
+        q.post(mpsc_destructor_counter{&count});
+        q.post(mpsc_destructor_counter{&count});
+        q.post(mpsc_destructor_counter{&count});
 
-        auto v1 = chan.try_pull();
+        auto v1 = q.try_pull();
         EXPECT_TRUE(static_cast<bool>(v1));
         auto v2 = std::move(v1);
         EXPECT_FALSE(static_cast<bool>(v1));
@@ -701,15 +699,14 @@ TEST_F(CATEGORY, try_pull_zc_scope_move) {
     {
       std::atomic<size_t> count{0};
       {
-        using qu =
-          tmc::qu_unbounded_mpsc<mpsc_destructor_counter, chan_config<0>>;
-        qu chan{};
-        chan.post(mpsc_destructor_counter{&count});
-        chan.post(mpsc_destructor_counter{&count});
+        using qu = tmc::qu_unbounded_mpsc<mpsc_destructor_counter, q_config<0>>;
+        qu q{};
+        q.post(mpsc_destructor_counter{&count});
+        q.post(mpsc_destructor_counter{&count});
 
         typename qu::try_pull_zc_scope dest;
         EXPECT_FALSE(static_cast<bool>(dest));
-        auto src = chan.try_pull();
+        auto src = q.try_pull();
         EXPECT_TRUE(static_cast<bool>(src));
         dest = std::move(src);
         EXPECT_FALSE(static_cast<bool>(src));
@@ -725,23 +722,23 @@ TEST_F(CATEGORY, try_pull_zc_scope_move) {
 TEST_F(CATEGORY, try_pull_empty_status) {
   test_async_main(ex(), []() -> tmc::task<void> {
     using qerr = tmc::qu_unbounded_mpsc_err;
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
 
     {
-      auto v = chan.try_pull();
+      auto v = q.try_pull();
       EXPECT_EQ(qerr::EMPTY, v.status());
       EXPECT_FALSE(static_cast<bool>(v));
     }
 
-    chan.post(static_cast<size_t>(7));
+    q.post(static_cast<size_t>(7));
     {
-      auto v2 = chan.try_pull();
+      auto v2 = q.try_pull();
       EXPECT_EQ(qerr::OK, v2.status());
       EXPECT_TRUE(static_cast<bool>(v2));
     }
 
     {
-      auto v3 = chan.try_pull();
+      auto v3 = q.try_pull();
       EXPECT_EQ(qerr::EMPTY, v3.status());
     }
     co_return;
@@ -755,37 +752,37 @@ TEST_F(CATEGORY, close_concurrent_post_bulk) {
   test_async_main(ex(), []() -> tmc::task<void> {
     static constexpr size_t NBULKS = 200;
     static constexpr size_t BULK_SIZE = 7;
-    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
     std::atomic<size_t> posted_ok{0};
 
     auto results = co_await tmc::spawn_tuple(
-      [&](auto& Chan) -> tmc::task<void> {
+      [&](auto& Q) -> tmc::task<void> {
         size_t vals[BULK_SIZE];
         for (size_t i = 0; i < BULK_SIZE; ++i) {
           vals[i] = 1;
         }
         for (size_t i = 0; i < NBULKS; ++i) {
-          if (Chan.post_bulk(&vals[0], BULK_SIZE)) {
+          if (Q.post_bulk(&vals[0], BULK_SIZE)) {
             posted_ok.fetch_add(BULK_SIZE, std::memory_order_relaxed);
           }
           if ((i & 0xF) == 0) {
             co_await tmc::reschedule();
           }
         }
-        Chan.close();
-        EXPECT_FALSE(Chan.post_bulk(&vals[0], BULK_SIZE));
+        Q.close();
+        EXPECT_FALSE(Q.post_bulk(&vals[0], BULK_SIZE));
         co_return;
-      }(chan),
-      [](auto& Chan) -> tmc::task<size_t> {
+      }(q),
+      [](auto& Q) -> tmc::task<size_t> {
         size_t pulled = 0;
         while (true) {
-          auto v = co_await Chan.pull();
+          auto v = co_await Q.pull();
           if (!v) {
             co_return pulled;
           }
           pulled += *v;
         }
-      }(chan)
+      }(q)
     );
 
     size_t pulled = std::get<1>(results);

--- a/tests/test_qu_mpsc.cpp
+++ b/tests/test_qu_mpsc.cpp
@@ -387,9 +387,9 @@ TEST_F(CATEGORY, close_concurrent_producer) {
   }());
 }
 
-// close_inline() behaves like close() for post(): subsequent posts fail and
-// pre-close posts still drain.
-TEST_F(CATEGORY, close_inline_basic_try_pull) {
+// close_resume_inline() behaves like close() for post(): subsequent posts fail
+// and pre-close posts still drain.
+TEST_F(CATEGORY, close_resume_inline_basic_try_pull) {
   test_async_main(ex(), []() -> tmc::task<void> {
     using qerr = tmc::qu_unbounded_mpsc_err;
     auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
@@ -398,9 +398,9 @@ TEST_F(CATEGORY, close_inline_basic_try_pull) {
       EXPECT_TRUE(q.post(i));
     }
 
-    q.close_inline();
+    q.close_resume_inline();
 
-    // post() after close_inline should fail.
+    // post() after close_resume_inline should fail.
     EXPECT_FALSE(q.post(static_cast<size_t>(99)));
 
     // Drain the queue.
@@ -414,7 +414,7 @@ TEST_F(CATEGORY, close_inline_basic_try_pull) {
       } else if (v.status() == qerr::CLOSED) {
         break;
       } else {
-        ADD_FAILURE() << "Unexpected EMPTY after close_inline";
+        ADD_FAILURE() << "Unexpected EMPTY after close_resume_inline";
         break;
       }
     }
@@ -429,12 +429,13 @@ TEST_F(CATEGORY, close_inline_basic_try_pull) {
   }());
 }
 
-// close_inline() with no values posted: try_pull immediately returns CLOSED.
-TEST_F(CATEGORY, close_inline_empty_try_pull) {
+// close_resume_inline() with no values posted: try_pull immediately returns
+// CLOSED.
+TEST_F(CATEGORY, close_resume_inline_empty_try_pull) {
   test_async_main(ex(), []() -> tmc::task<void> {
     using qerr = tmc::qu_unbounded_mpsc_err;
     auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
-    q.close_inline();
+    q.close_resume_inline();
 
     auto v = q.try_pull();
     EXPECT_EQ(qerr::CLOSED, v.status());
@@ -443,14 +444,14 @@ TEST_F(CATEGORY, close_inline_empty_try_pull) {
   }());
 }
 
-// close_inline() is idempotent and may be intermixed with close().
-TEST_F(CATEGORY, close_inline_idempotent) {
+// close_resume_inline() is idempotent and may be intermixed with close().
+TEST_F(CATEGORY, close_resume_inline_idempotent) {
   test_async_main(ex(), []() -> tmc::task<void> {
     auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
-    q.close_inline();
-    q.close_inline();
+    q.close_resume_inline();
+    q.close_resume_inline();
     q.close();
-    q.close_inline();
+    q.close_resume_inline();
     EXPECT_FALSE(q.post(static_cast<size_t>(1)));
     co_return;
   }());
@@ -458,14 +459,14 @@ TEST_F(CATEGORY, close_inline_idempotent) {
 
 // pull() resumes with an empty scope when the queue is closed_inline and
 // drained.
-TEST_F(CATEGORY, close_inline_pull_drains_then_returns_empty) {
+TEST_F(CATEGORY, close_resume_inline_pull_drains_then_returns_empty) {
   test_async_main(ex(), []() -> tmc::task<void> {
     auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
 
     for (size_t i = 0; i < 3; ++i) {
       EXPECT_TRUE(q.post(i));
     }
-    q.close_inline();
+    q.close_resume_inline();
 
     // Drain via pull().
     size_t count = 0;
@@ -484,11 +485,11 @@ TEST_F(CATEGORY, close_inline_pull_drains_then_returns_empty) {
   }());
 }
 
-// close_inline() wakes a consumer suspended on an empty slot, just like
+// close_resume_inline() wakes a consumer suspended on an empty slot, just like
 // close() does. The consumer is parked at slot 0 (no producer has posted),
-// then close_inline() races in and publishes the CLOSED sentinel at slot 0,
-// which wakes the consumer with an empty scope.
-TEST_F(CATEGORY, close_inline_wakes_suspended_consumer) {
+// then close_resume_inline() races in and publishes the CLOSED sentinel at slot
+// 0, which wakes the consumer with an empty scope.
+TEST_F(CATEGORY, close_resume_inline_wakes_suspended_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
     auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
 
@@ -502,13 +503,15 @@ TEST_F(CATEGORY, close_inline_wakes_suspended_consumer) {
         for (size_t i = 0; i < 10; ++i) {
           co_await tmc::reschedule();
         }
-        Q.close_inline();
+        Q.close_resume_inline();
         co_return;
       }(q)
     );
 
     bool got_value = std::get<0>(results);
-    EXPECT_FALSE(got_value); // consumer was woken by close_inline with empty
+    EXPECT_FALSE(
+      got_value
+    ); // consumer was woken by close_resume_inline with empty
     co_return;
   }());
 }

--- a/tests/test_qu_mpsc.cpp
+++ b/tests/test_qu_mpsc.cpp
@@ -718,6 +718,69 @@ TEST_F(CATEGORY, try_pull_zc_scope_move) {
   }());
 }
 
+// Move-assignment of try_pull_zc_scope when the destination already holds a
+// value. Two distinct queues are used because the API requires that at most
+// one scope from a given queue be live at a time. The destination scope's
+// element must be released (destroyed + slot freed) before adopting the
+// source's element.
+TEST_F(CATEGORY, try_pull_zc_scope_move_assign_over_nonempty) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    std::atomic<size_t> count1{0};
+    std::atomic<size_t> count2{0};
+    {
+      auto q1 = tmc::qu_unbounded_mpsc<mpsc_destructor_counter, q_config<0>>{};
+      auto q2 = tmc::qu_unbounded_mpsc<mpsc_destructor_counter, q_config<0>>{};
+      q1.post(mpsc_destructor_counter{&count1});
+      q2.post(mpsc_destructor_counter{&count2});
+
+      auto v1 = q1.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v1));
+      auto v2 = q2.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v2));
+      EXPECT_EQ(0u, count1.load());
+      EXPECT_EQ(0u, count2.load());
+
+      // Move-assign over a non-empty scope. v1's existing element (from q1)
+      // must be destroyed and its slot released; v1 then takes ownership of
+      // v2's element (from q2).
+      v1 = std::move(v2);
+      EXPECT_FALSE(static_cast<bool>(v2));
+      EXPECT_TRUE(static_cast<bool>(v1));
+      EXPECT_EQ(1u, count1.load()); // q1's slot was destroyed by the assign
+      EXPECT_EQ(0u, count2.load()); // q2's element now lives in v1
+    } // ~v1 destroys q2's element (count2 -> 1); both queues then destruct.
+    EXPECT_EQ(1u, count1.load());
+    EXPECT_EQ(1u, count2.load());
+    co_return;
+  }());
+}
+
+// Self-move-assignment of try_pull_zc_scope must be a no-op: the held value
+// stays valid and the slot is not double-released. (This exercises the
+// `this != &Other` early-out branch in operator=.)
+TEST_F(CATEGORY, try_pull_zc_scope_self_move_assign) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    std::atomic<size_t> count{0};
+    {
+      auto q = tmc::qu_unbounded_mpsc<mpsc_destructor_counter, q_config<0>>{};
+      q.post(mpsc_destructor_counter{&count});
+
+      auto v = q.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+
+      // Self-move-assign through a reference to defeat compiler warnings.
+      auto& vref = v;
+      v = std::move(vref);
+
+      EXPECT_TRUE(static_cast<bool>(v));
+      EXPECT_NE(v->count, nullptr);
+      EXPECT_EQ(0u, count.load());
+    }
+    EXPECT_EQ(1u, count.load());
+    co_return;
+  }());
+}
+
 // Explicit EMPTY status before close().
 TEST_F(CATEGORY, try_pull_empty_status) {
   test_async_main(ex(), []() -> tmc::task<void> {
@@ -788,6 +851,140 @@ TEST_F(CATEGORY, close_concurrent_post_bulk) {
     size_t pulled = std::get<1>(results);
     EXPECT_EQ(posted_ok.load(), pulled);
     EXPECT_EQ(NBULKS * BULK_SIZE, pulled);
+    co_return;
+  }());
+}
+
+// Type that requires multiple arguments to construct. Used to verify that
+// post() forwards a variadic argument pack and constructs T in-place.
+struct mpsc_multi_arg {
+  size_t a;
+  size_t b;
+  size_t c;
+  mpsc_multi_arg(size_t A, size_t B, size_t C) noexcept : a{A}, b{B}, c{C} {}
+  mpsc_multi_arg(size_t A, size_t B) noexcept : a{A}, b{B}, c{0} {}
+};
+
+// post() forwards variadic arguments and constructs T in-place.
+TEST_F(CATEGORY, post_variadic_args) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto q = tmc::qu_unbounded_mpsc<mpsc_multi_arg, q_config<0>>{};
+
+    // Single-argument form: construct from an existing T.
+    EXPECT_TRUE(q.post(mpsc_multi_arg{1, 2, 3}));
+    // Two-argument form.
+    EXPECT_TRUE(q.post(static_cast<size_t>(4), static_cast<size_t>(5)));
+    // Three-argument form: construct in-place from (size_t, size_t, size_t).
+    EXPECT_TRUE(q.post(
+      static_cast<size_t>(6), static_cast<size_t>(7), static_cast<size_t>(8)
+    ));
+
+    {
+      auto v = q.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      EXPECT_EQ(1u, v->a);
+      EXPECT_EQ(2u, v->b);
+      EXPECT_EQ(3u, v->c);
+    }
+    {
+      auto v = q.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      EXPECT_EQ(4u, v->a);
+      EXPECT_EQ(5u, v->b);
+      EXPECT_EQ(0u, v->c);
+    }
+    {
+      auto v = q.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      EXPECT_EQ(6u, v->a);
+      EXPECT_EQ(7u, v->b);
+      EXPECT_EQ(8u, v->c);
+    }
+    co_return;
+  }());
+}
+
+// post_bulk(Begin, End) iterator-pair overload.
+TEST_F(CATEGORY, post_bulk_iter_pair) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+
+    std::vector<size_t> vals;
+    for (size_t i = 0; i < 10; ++i) {
+      vals.push_back(i);
+    }
+    EXPECT_TRUE(q.post_bulk(vals.begin(), vals.end()));
+
+    size_t count = 0;
+    size_t sum = 0;
+    for (size_t i = 0; i < 10; ++i) {
+      auto v = q.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      sum += *v;
+      ++count;
+    }
+    EXPECT_EQ(10u, count);
+    EXPECT_EQ(0u + 1u + 2u + 3u + 4u + 5u + 6u + 7u + 8u + 9u, sum);
+
+    auto empty = q.try_pull();
+    EXPECT_FALSE(static_cast<bool>(empty));
+    co_return;
+  }());
+}
+
+// post_bulk(Range) range overload.
+TEST_F(CATEGORY, post_bulk_range) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+
+    std::vector<size_t> vals;
+    for (size_t i = 0; i < 10; ++i) {
+      vals.push_back(i);
+    }
+    EXPECT_TRUE(q.post_bulk(vals));
+
+    size_t count = 0;
+    size_t sum = 0;
+    for (size_t i = 0; i < 10; ++i) {
+      auto v = q.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      sum += *v;
+      ++count;
+    }
+    EXPECT_EQ(10u, count);
+    EXPECT_EQ(0u + 1u + 2u + 3u + 4u + 5u + 6u + 7u + 8u + 9u, sum);
+
+    auto empty = q.try_pull();
+    EXPECT_FALSE(static_cast<bool>(empty));
+    co_return;
+  }());
+}
+
+// All 3 post_bulk forms accept zero-element inputs and become no-ops.
+TEST_F(CATEGORY, post_bulk_empty_all_forms) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+
+    // (iter, count) form with count == 0.
+    size_t dummy = 0;
+    EXPECT_TRUE(q.post_bulk(&dummy, 0));
+
+    // (begin, end) form with begin == end.
+    std::vector<size_t> empty_vec;
+    EXPECT_TRUE(q.post_bulk(empty_vec.begin(), empty_vec.end()));
+
+    // (range) form with an empty range.
+    EXPECT_TRUE(q.post_bulk(empty_vec));
+
+    // None of the calls should have produced any elements.
+    auto v = q.try_pull();
+    EXPECT_FALSE(static_cast<bool>(v));
+
+    // The queue must still be usable after the no-op bulk posts.
+    EXPECT_TRUE(q.post(static_cast<size_t>(42)));
+    auto v2 = q.try_pull();
+    EXPECT_TRUE(static_cast<bool>(v2));
+    EXPECT_EQ(42u, *v2);
     co_return;
   }());
 }

--- a/tests/test_qu_mpsc.cpp
+++ b/tests/test_qu_mpsc.cpp
@@ -1,6 +1,6 @@
 #include "test_common.hpp"
 #include "tmc/detail/compat.hpp"
-#include "tmc/detail/qu_mpsc.hpp"
+#include "tmc/qu_unbounded_mpsc.hpp"
 
 #include <cstddef>
 #include <gtest/gtest.h>
@@ -19,7 +19,8 @@ protected:
 
 static constexpr size_t MPSC_TEST_SENTINEL = static_cast<size_t>(-1);
 
-template <size_t Pack> struct chan_config : tmc::detail::qu_mpsc_default_config {
+template <size_t Pack>
+struct chan_config : tmc::qu_unbounded_mpsc_default_config {
   // Use a small block size to ensure that alloc / reclaim is triggered.
   static inline constexpr size_t BlockSize = 2;
   static inline constexpr size_t PackingLevel = Pack;
@@ -64,7 +65,7 @@ void do_chan_test(Executor& Exec) {
         size_t sum;
       };
 
-      auto chan = tmc::detail::qu_mpsc<size_t, chan_config<PackingLevel>>{};
+      auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<PackingLevel>>{};
 
       auto results = co_await tmc::spawn_tuple(
         [](auto& Chan) -> tmc::task<size_t> {
@@ -79,12 +80,12 @@ void do_chan_test(Executor& Exec) {
           size_t count = 0;
           size_t sum = 0;
           while (true) {
-            size_t v = co_await Chan.pull();
-            if (v == MPSC_TEST_SENTINEL) {
+            auto v = co_await Chan.pull();
+            if (*v == MPSC_TEST_SENTINEL) {
               co_return result{count, sum};
             }
             ++count;
-            sum += v;
+            sum += *v;
           }
         }(chan)
       );
@@ -106,7 +107,7 @@ void do_chan_test(Executor& Exec) {
         size_t sum;
       };
 
-      auto chan = tmc::detail::qu_mpsc<size_t, chan_config<PackingLevel>>{};
+      auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<PackingLevel>>{};
 
       auto results = co_await tmc::spawn_tuple(
         [](auto& Chan) -> tmc::task<size_t> {
@@ -124,12 +125,13 @@ void do_chan_test(Executor& Exec) {
           size_t count = 0;
           size_t sum = 0;
           for (size_t i = 0; i < NITEMS; ++i) {
-            size_t v;
-            while (!Chan.try_pull(v)) {
+            auto v = Chan.try_pull();
+            while (!v) {
               TMC_CPU_PAUSE();
+              v = Chan.try_pull();
             }
             ++count;
-            sum += v;
+            sum += *v;
           }
           co_return result{count, sum};
         }(chan)
@@ -148,16 +150,15 @@ void do_chan_test(Executor& Exec) {
       // destroy chan with data remaining inside
       std::atomic<size_t> count;
       {
-        auto chan = tmc::detail::qu_mpsc<
+        auto chan = tmc::qu_unbounded_mpsc<
           mpsc_destructor_counter, chan_config<PackingLevel>>{};
         for (size_t i = 0; i < 12; ++i) {
           chan.post(mpsc_destructor_counter{&count});
         }
 
         for (size_t i = 0; i < 7; ++i) {
-          mpsc_destructor_counter v;
-          auto ok = chan.try_pull(v);
-          EXPECT_TRUE(ok);
+          auto ok = chan.try_pull();
+          EXPECT_TRUE(static_cast<bool>(ok));
         }
 
         EXPECT_EQ(count.load(), 7);
@@ -178,9 +179,8 @@ TEST_F(CATEGORY, post_bulk_none) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::detail::qu_mpsc<size_t, chan_config<0>>{};
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
     size_t i = 0;
-    bool ok;
     for (; i < 4; ++i) {
       chan.post_bulk(&i, 0);
       chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
@@ -194,17 +194,603 @@ TEST_F(CATEGORY, post_bulk_none) {
     size_t count = 0;
     size_t sum = 0;
     for (size_t j = 0; j < i; ++j) {
-      size_t v;
-      EXPECT_TRUE(chan.try_pull(v));
-      sum += v;
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      sum += *v;
       ++count;
     }
     EXPECT_EQ(28, sum);
     EXPECT_EQ(8, count);
 
-    size_t v;
-    ok = chan.try_pull(v);
-    EXPECT_FALSE(ok);
+    auto v = chan.try_pull();
+    EXPECT_FALSE(static_cast<bool>(v));
+    co_return;
+  }());
+}
+
+// close() makes subsequent post() return false. Pre-close posts still drain.
+TEST_F(CATEGORY, close_basic_try_pull) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    using qerr = tmc::qu_unbounded_mpsc_err;
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+
+    for (size_t i = 0; i < 5; ++i) {
+      EXPECT_TRUE(chan.post(i));
+    }
+
+    chan.close();
+
+    // post() after close should fail.
+    EXPECT_FALSE(chan.post(static_cast<size_t>(99)));
+
+    // Drain the queue.
+    size_t sum = 0;
+    size_t count = 0;
+    while (true) {
+      auto v = chan.try_pull();
+      if (v.status() == qerr::OK) {
+        sum += *v;
+        ++count;
+      } else if (v.status() == qerr::CLOSED) {
+        break;
+      } else {
+        // Spin on EMPTY (shouldn't happen here since producers all finished).
+        ADD_FAILURE() << "Unexpected EMPTY after close";
+        break;
+      }
+    }
+    EXPECT_EQ(5u, count);
+    EXPECT_EQ(0u + 1u + 2u + 3u + 4u, sum);
+
+    // Further try_pull stays CLOSED.
+    auto v = chan.try_pull();
+    EXPECT_EQ(qerr::CLOSED, v.status());
+    EXPECT_FALSE(static_cast<bool>(v));
+    co_return;
+  }());
+}
+
+// close() with no values posted: try_pull immediately returns CLOSED.
+TEST_F(CATEGORY, close_empty_try_pull) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    using qerr = tmc::qu_unbounded_mpsc_err;
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    chan.close();
+
+    auto v = chan.try_pull();
+    EXPECT_EQ(qerr::CLOSED, v.status());
+    EXPECT_FALSE(static_cast<bool>(v));
+    co_return;
+  }());
+}
+
+// close() is idempotent.
+TEST_F(CATEGORY, close_idempotent) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    chan.close();
+    chan.close();
+    chan.close();
+    EXPECT_FALSE(chan.post(static_cast<size_t>(1)));
+    co_return;
+  }());
+}
+
+// pull() resumes with an empty scope when the queue is closed and drained.
+TEST_F(CATEGORY, close_pull_drains_then_returns_empty) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+
+    for (size_t i = 0; i < 3; ++i) {
+      EXPECT_TRUE(chan.post(i));
+    }
+    chan.close();
+
+    // Drain via pull().
+    size_t count = 0;
+    size_t sum = 0;
+    while (true) {
+      auto v = co_await chan.pull();
+      if (!v) {
+        break; // closed and drained
+      }
+      sum += *v;
+      ++count;
+    }
+    EXPECT_EQ(3u, count);
+    EXPECT_EQ(0u + 1u + 2u, sum);
+    co_return;
+  }());
+}
+
+// close() wakes a consumer suspended on an empty slot. The consumer is parked
+// at slot 0 (no producer has posted), then close() races in and publishes the
+// CLOSED sentinel at slot 0, which wakes the consumer with an empty scope.
+TEST_F(CATEGORY, close_wakes_suspended_consumer) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+
+    auto results = co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<bool> {
+        auto v = co_await Chan.pull();
+        co_return static_cast<bool>(v);
+      }(chan),
+      [](auto& Chan) -> tmc::task<void> {
+        // Yield to give the consumer a chance to suspend.
+        for (size_t i = 0; i < 10; ++i) {
+          co_await tmc::reschedule();
+        }
+        Chan.close();
+        co_return;
+      }(chan)
+    );
+
+    bool got_value = std::get<0>(results);
+    EXPECT_FALSE(got_value); // consumer was woken by close with empty scope
+    co_return;
+  }());
+}
+
+// post_bulk() returns false when called after close.
+TEST_F(CATEGORY, close_post_bulk_returns_false) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    chan.close();
+
+    size_t vals[3] = {10, 11, 12};
+    EXPECT_FALSE(chan.post_bulk(&vals[0], 3));
+    co_return;
+  }());
+}
+
+// Concurrent producer + close: every post() that returns true must be
+// observed by the consumer, and once close returns, subsequent posts fail.
+TEST_F(CATEGORY, close_concurrent_producer) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    static constexpr size_t NITEMS = 2000;
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    std::atomic<size_t> posted_ok{0};
+
+    auto results = co_await tmc::spawn_tuple(
+      [&](auto& Chan) -> tmc::task<void> {
+        for (size_t i = 0; i < NITEMS; ++i) {
+          if (Chan.post(static_cast<size_t>(1))) {
+            posted_ok.fetch_add(1, std::memory_order_relaxed);
+          }
+          // Yield occasionally to allow other tasks to run.
+          if ((i & 0x3F) == 0) {
+            co_await tmc::reschedule();
+          }
+        }
+        // After this producer is done, close the queue. There are no other
+        // producers, so all posts() that succeeded are pre-close.
+        Chan.close();
+        // Subsequent posts must fail.
+        EXPECT_FALSE(Chan.post(static_cast<size_t>(999)));
+        co_return;
+      }(chan),
+      [](auto& Chan) -> tmc::task<size_t> {
+        size_t pulled = 0;
+        while (true) {
+          auto v = co_await Chan.pull();
+          if (!v) {
+            co_return pulled;
+          }
+          pulled += *v;
+        }
+      }(chan)
+    );
+
+    size_t pulled = std::get<1>(results);
+    EXPECT_EQ(posted_ok.load(), pulled);
+    EXPECT_EQ(NITEMS, pulled);
+    co_return;
+  }());
+}
+
+// close_inline() behaves like close() for post(): subsequent posts fail and
+// pre-close posts still drain.
+TEST_F(CATEGORY, close_inline_basic_try_pull) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    using qerr = tmc::qu_unbounded_mpsc_err;
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+
+    for (size_t i = 0; i < 5; ++i) {
+      EXPECT_TRUE(chan.post(i));
+    }
+
+    chan.close_inline();
+
+    // post() after close_inline should fail.
+    EXPECT_FALSE(chan.post(static_cast<size_t>(99)));
+
+    // Drain the queue.
+    size_t sum = 0;
+    size_t count = 0;
+    while (true) {
+      auto v = chan.try_pull();
+      if (v.status() == qerr::OK) {
+        sum += *v;
+        ++count;
+      } else if (v.status() == qerr::CLOSED) {
+        break;
+      } else {
+        ADD_FAILURE() << "Unexpected EMPTY after close_inline";
+        break;
+      }
+    }
+    EXPECT_EQ(5u, count);
+    EXPECT_EQ(0u + 1u + 2u + 3u + 4u, sum);
+
+    // Further try_pull stays CLOSED.
+    auto v = chan.try_pull();
+    EXPECT_EQ(qerr::CLOSED, v.status());
+    EXPECT_FALSE(static_cast<bool>(v));
+    co_return;
+  }());
+}
+
+// close_inline() with no values posted: try_pull immediately returns CLOSED.
+TEST_F(CATEGORY, close_inline_empty_try_pull) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    using qerr = tmc::qu_unbounded_mpsc_err;
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    chan.close_inline();
+
+    auto v = chan.try_pull();
+    EXPECT_EQ(qerr::CLOSED, v.status());
+    EXPECT_FALSE(static_cast<bool>(v));
+    co_return;
+  }());
+}
+
+// close_inline() is idempotent and may be intermixed with close().
+TEST_F(CATEGORY, close_inline_idempotent) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    chan.close_inline();
+    chan.close_inline();
+    chan.close();
+    chan.close_inline();
+    EXPECT_FALSE(chan.post(static_cast<size_t>(1)));
+    co_return;
+  }());
+}
+
+// pull() resumes with an empty scope when the queue is closed_inline and
+// drained.
+TEST_F(CATEGORY, close_inline_pull_drains_then_returns_empty) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+
+    for (size_t i = 0; i < 3; ++i) {
+      EXPECT_TRUE(chan.post(i));
+    }
+    chan.close_inline();
+
+    // Drain via pull().
+    size_t count = 0;
+    size_t sum = 0;
+    while (true) {
+      auto v = co_await chan.pull();
+      if (!v) {
+        break; // closed and drained
+      }
+      sum += *v;
+      ++count;
+    }
+    EXPECT_EQ(3u, count);
+    EXPECT_EQ(0u + 1u + 2u, sum);
+    co_return;
+  }());
+}
+
+// close_inline() wakes a consumer suspended on an empty slot, just like
+// close() does. The consumer is parked at slot 0 (no producer has posted),
+// then close_inline() races in and publishes the CLOSED sentinel at slot 0,
+// which wakes the consumer with an empty scope.
+TEST_F(CATEGORY, close_inline_wakes_suspended_consumer) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+
+    auto results = co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<bool> {
+        auto v = co_await Chan.pull();
+        co_return static_cast<bool>(v);
+      }(chan),
+      [](auto& Chan) -> tmc::task<void> {
+        // Yield to give the consumer a chance to suspend.
+        for (size_t i = 0; i < 10; ++i) {
+          co_await tmc::reschedule();
+        }
+        Chan.close_inline();
+        co_return;
+      }(chan)
+    );
+
+    bool got_value = std::get<0>(results);
+    EXPECT_FALSE(got_value); // consumer was woken by close_inline with empty
+    co_return;
+  }());
+}
+
+// Config that uses the default ConsumerCanSuspend = false. This exercises
+// the non-suspending code path in write_element (set_data_ready()), which
+// chan_config<> overrides to true and which is otherwise never tested.
+struct chan_config_no_suspend : tmc::qu_unbounded_mpsc_default_config {
+  static inline constexpr size_t BlockSize = 2;
+  // ConsumerCanSuspend defaults to false
+};
+
+TEST_F(CATEGORY, no_suspend_try_pull_only) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    using qerr = tmc::qu_unbounded_mpsc_err;
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config_no_suspend>{};
+
+    // No data available yet: try_pull returns EMPTY.
+    {
+      auto v = chan.try_pull();
+      EXPECT_EQ(qerr::EMPTY, v.status());
+      EXPECT_FALSE(static_cast<bool>(v));
+    }
+
+    static constexpr size_t NITEMS = 100;
+    for (size_t i = 0; i < NITEMS; ++i) {
+      EXPECT_TRUE(chan.post(i));
+    }
+
+    size_t sum = 0;
+    size_t count = 0;
+    for (size_t i = 0; i < NITEMS; ++i) {
+      auto v = chan.try_pull();
+      EXPECT_EQ(qerr::OK, v.status());
+      EXPECT_TRUE(static_cast<bool>(v));
+      sum += *v;
+      ++count;
+    }
+    EXPECT_EQ(NITEMS, count);
+    size_t expected = 0;
+    for (size_t i = 0; i < NITEMS; ++i) {
+      expected += i;
+    }
+    EXPECT_EQ(expected, sum);
+
+    // After draining: EMPTY again.
+    auto v = chan.try_pull();
+    EXPECT_EQ(qerr::EMPTY, v.status());
+    EXPECT_FALSE(static_cast<bool>(v));
+
+    // Close and verify CLOSED status.
+    chan.close();
+    auto v2 = chan.try_pull();
+    EXPECT_EQ(qerr::CLOSED, v2.status());
+    co_return;
+  }());
+}
+
+// EmbedFirstBlock = true: first block is embedded in the qu_mpsc object.
+// Push and reclaim past the embedded block to ensure the destructor handles
+// the embedded-vs-heap distinction correctly.
+struct chan_config_embed : tmc::qu_unbounded_mpsc_default_config {
+  static inline constexpr size_t BlockSize = 2;
+  static inline constexpr bool EmbedFirstBlock = true;
+  static inline constexpr bool ConsumerCanSuspend = true;
+};
+
+TEST_F(CATEGORY, embed_first_block) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config_embed>{};
+    static constexpr size_t NITEMS = 50; // many block transitions
+    size_t sum = 0;
+    for (size_t i = 0; i < NITEMS; ++i) {
+      EXPECT_TRUE(chan.post(i));
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      sum += *v;
+    }
+    size_t expected = 0;
+    for (size_t i = 0; i < NITEMS; ++i) {
+      expected += i;
+    }
+    EXPECT_EQ(expected, sum);
+    co_return;
+  }());
+
+  // Also test the destructor path when the embedded block holds undrained
+  // data. This ensures we don't try to delete the embedded block.
+  {
+    std::atomic<size_t> count{0};
+    {
+      auto chan =
+        tmc::qu_unbounded_mpsc<mpsc_destructor_counter, chan_config_embed>{};
+      // 2 items fit in the embedded block (BlockSize=2). Add more to also
+      // exercise heap blocks alongside the embedded block.
+      for (size_t i = 0; i < 5; ++i) {
+        chan.post(mpsc_destructor_counter{&count});
+      }
+    }
+    EXPECT_EQ(count.load(), 5);
+  }
+}
+
+// Multiple concurrent producers. This is what the M in MPSC stands for; the
+// existing tests only use a single producer task.
+TEST_F(CATEGORY, multi_producer) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    static constexpr size_t NPRODUCERS = 4;
+    static constexpr size_t PER_PRODUCER = 500;
+    static constexpr size_t TOTAL = NPRODUCERS * PER_PRODUCER;
+
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+
+    auto results = co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<size_t> {
+        // Producer orchestrator: spawn NPRODUCERS producers in parallel.
+        std::vector<tmc::task<size_t>> producers;
+        for (size_t p = 0; p < NPRODUCERS; ++p) {
+          producers.push_back([](auto& C, size_t Base) -> tmc::task<size_t> {
+            size_t produced = 0;
+            for (size_t i = 0; i < PER_PRODUCER; ++i) {
+              C.post(Base + i);
+              ++produced;
+              if ((i & 0x1F) == 0) {
+                co_await tmc::reschedule();
+              }
+            }
+            co_return produced;
+          }(Chan, p * PER_PRODUCER));
+        }
+        auto counts =
+          co_await tmc::spawn_many(producers.data(), producers.size());
+        size_t totalProduced = 0;
+        for (auto c : counts) {
+          totalProduced += c;
+        }
+        // Wake the consumer.
+        Chan.post(MPSC_TEST_SENTINEL);
+        co_return totalProduced;
+      }(chan),
+      [](auto& Chan) -> tmc::task<size_t> {
+        size_t pulled = 0;
+        while (true) {
+          auto v = co_await Chan.pull();
+          if (!v) {
+            co_return pulled;
+          }
+          if (*v == MPSC_TEST_SENTINEL) {
+            co_return pulled;
+          }
+          ++pulled;
+        }
+      }(chan)
+    );
+
+    EXPECT_EQ(TOTAL, std::get<0>(results));
+    EXPECT_EQ(TOTAL, std::get<1>(results));
+    co_return;
+  }());
+}
+
+// Move construction / move assignment of try_pull_zc_scope. Ensures the
+// moved-from scope releases its slot exactly once and the moved-to scope
+// can still read the value.
+TEST_F(CATEGORY, try_pull_zc_scope_move) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    // Move-construct.
+    {
+      std::atomic<size_t> count{0};
+      {
+        auto chan =
+          tmc::qu_unbounded_mpsc<mpsc_destructor_counter, chan_config<0>>{};
+        chan.post(mpsc_destructor_counter{&count});
+        chan.post(mpsc_destructor_counter{&count});
+        chan.post(mpsc_destructor_counter{&count});
+
+        auto v1 = chan.try_pull();
+        EXPECT_TRUE(static_cast<bool>(v1));
+        auto v2 = std::move(v1);
+        EXPECT_FALSE(static_cast<bool>(v1));
+        EXPECT_TRUE(static_cast<bool>(v2));
+        EXPECT_NE(v2->count, nullptr);
+        // v1's destructor must be a no-op; only v2's release the slot.
+      } // v2 destructor releases slot 0; remaining 2 destroyed by ~qu_mpsc
+      EXPECT_EQ(count.load(), 3);
+    }
+
+    // Move-assign over an empty scope.
+    {
+      std::atomic<size_t> count{0};
+      {
+        using qu =
+          tmc::qu_unbounded_mpsc<mpsc_destructor_counter, chan_config<0>>;
+        qu chan{};
+        chan.post(mpsc_destructor_counter{&count});
+        chan.post(mpsc_destructor_counter{&count});
+
+        typename qu::try_pull_zc_scope dest;
+        EXPECT_FALSE(static_cast<bool>(dest));
+        auto src = chan.try_pull();
+        EXPECT_TRUE(static_cast<bool>(src));
+        dest = std::move(src);
+        EXPECT_FALSE(static_cast<bool>(src));
+        EXPECT_TRUE(static_cast<bool>(dest));
+      }
+      EXPECT_EQ(count.load(), 2);
+    }
+    co_return;
+  }());
+}
+
+// Explicit EMPTY status before close().
+TEST_F(CATEGORY, try_pull_empty_status) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    using qerr = tmc::qu_unbounded_mpsc_err;
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+
+    {
+      auto v = chan.try_pull();
+      EXPECT_EQ(qerr::EMPTY, v.status());
+      EXPECT_FALSE(static_cast<bool>(v));
+    }
+
+    chan.post(static_cast<size_t>(7));
+    {
+      auto v2 = chan.try_pull();
+      EXPECT_EQ(qerr::OK, v2.status());
+      EXPECT_TRUE(static_cast<bool>(v2));
+    }
+
+    {
+      auto v3 = chan.try_pull();
+      EXPECT_EQ(qerr::EMPTY, v3.status());
+    }
+    co_return;
+  }());
+}
+
+// Concurrent post_bulk + close. Verifies the bulk-reservation close protocol:
+// each post_bulk that returns true must be fully drained; post_bulks issued
+// after close return false.
+TEST_F(CATEGORY, close_concurrent_post_bulk) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    static constexpr size_t NBULKS = 200;
+    static constexpr size_t BULK_SIZE = 7;
+    auto chan = tmc::qu_unbounded_mpsc<size_t, chan_config<0>>{};
+    std::atomic<size_t> posted_ok{0};
+
+    auto results = co_await tmc::spawn_tuple(
+      [&](auto& Chan) -> tmc::task<void> {
+        size_t vals[BULK_SIZE];
+        for (size_t i = 0; i < BULK_SIZE; ++i) {
+          vals[i] = 1;
+        }
+        for (size_t i = 0; i < NBULKS; ++i) {
+          if (Chan.post_bulk(&vals[0], BULK_SIZE)) {
+            posted_ok.fetch_add(BULK_SIZE, std::memory_order_relaxed);
+          }
+          if ((i & 0xF) == 0) {
+            co_await tmc::reschedule();
+          }
+        }
+        Chan.close();
+        EXPECT_FALSE(Chan.post_bulk(&vals[0], BULK_SIZE));
+        co_return;
+      }(chan),
+      [](auto& Chan) -> tmc::task<size_t> {
+        size_t pulled = 0;
+        while (true) {
+          auto v = co_await Chan.pull();
+          if (!v) {
+            co_return pulled;
+          }
+          pulled += *v;
+        }
+      }(chan)
+    );
+
+    size_t pulled = std::get<1>(results);
+    EXPECT_EQ(posted_ok.load(), pulled);
+    EXPECT_EQ(NBULKS * BULK_SIZE, pulled);
     co_return;
   }());
 }


### PR DESCRIPTION
Tests for https://github.com/tzcnt/TooManyCooks/pull/228

Also adds a new `qu_mpsc_bench`. I'm not sure that this is going to stick around long-term, but I've also been using it to test `qu_unbounded_spsc`.

Also adds `coverage.sh`, a script to generate test coverage reports for local testing (so I can check for missing coverage without relying on coverage.io)