### PR TITLE
use waiter_count() instead of sleeping in tests

### DIFF
--- a/tests/test_atomic_condvar.cpp
+++ b/tests/test_atomic_condvar.cpp
@@ -67,7 +67,7 @@ TEST_F(CATEGORY, one_waiter) {
     tmc::atomic_condvar<int> cv(1);
     atomic_awaitable<int> aa(1);
     auto t = tmc::spawn(make_waiter(cv, aa)).fork();
-    waiter_count_accessor::wait_for_waiter_count(cv, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(cv, 1);
     EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
     EXPECT_EQ(aa.load(), 0);
     cv.ref()++;
@@ -86,14 +86,14 @@ TEST_F(CATEGORY, multi_waiter) {
       tasks[i] = make_waiter(cv, aa);
     }
     auto t = tmc::spawn_many(tasks).fork();
-    waiter_count_accessor::wait_for_waiter_count(cv, 5);
+    co_await waiter_count_accessor::wait_for_waiter_count(cv, 5);
     EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
     EXPECT_EQ(aa.load(), 0);
     cv.ref()++;
     cv.notify_one();
-    waiter_count_accessor::wait_for_waiter_count(cv, 4);
+    co_await waiter_count_accessor::wait_for_waiter_count(cv, 4);
     cv.notify_n(2);
-    waiter_count_accessor::wait_for_waiter_count(cv, 2);
+    co_await waiter_count_accessor::wait_for_waiter_count(cv, 2);
     cv.notify_all();
     co_await aa;
     EXPECT_EQ(aa.load(), 5);
@@ -107,7 +107,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
     std::optional<tmc::atomic_condvar<int>> cv;
     cv.emplace(1);
     auto t = tmc::spawn(make_waiter(*cv, aa)).fork();
-    waiter_count_accessor::wait_for_waiter_count(*cv, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(*cv, 1);
     EXPECT_EQ(aa.load(), 0);
 
     // Notify 0 waiters
@@ -140,7 +140,7 @@ TEST_F(CATEGORY, co_notify_one) {
       tmc::atomic_condvar<int> cv(1);
       atomic_awaitable<int> aa(1);
       auto t = tmc::spawn(make_waiter(cv, aa)).fork();
-      waiter_count_accessor::wait_for_waiter_count(cv, 1);
+      co_await waiter_count_accessor::wait_for_waiter_count(cv, 1);
       EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
       EXPECT_EQ(aa.load(), 0);
       cv.ref()++;
@@ -157,7 +157,7 @@ TEST_F(CATEGORY, co_notify_one) {
       )
                  .with_priority(1)
                  .fork();
-      waiter_count_accessor::wait_for_waiter_count(cv, 1);
+      co_await waiter_count_accessor::wait_for_waiter_count(cv, 1);
       EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
       EXPECT_EQ(aa.load(), 0);
       cv.ref()++;
@@ -175,7 +175,7 @@ TEST_F(CATEGORY, co_notify_n) {
       atomic_awaitable<int> aa(2);
       auto t =
         tmc::spawn_tuple(make_waiter(cv, aa), make_waiter(cv, aa)).fork();
-      waiter_count_accessor::wait_for_waiter_count(cv, 2);
+      co_await waiter_count_accessor::wait_for_waiter_count(cv, 2);
       EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
       EXPECT_EQ(aa.load(), 0);
       cv.ref()++;
@@ -189,7 +189,7 @@ TEST_F(CATEGORY, co_notify_n) {
       auto t = tmc::spawn_tuple(make_waiter(cv, aa), make_waiter(cv, aa))
                  .with_priority(1)
                  .fork();
-      waiter_count_accessor::wait_for_waiter_count(cv, 2);
+      co_await waiter_count_accessor::wait_for_waiter_count(cv, 2);
       EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
       EXPECT_EQ(aa.load(), 0);
       cv.ref()++;
@@ -207,7 +207,7 @@ TEST_F(CATEGORY, co_notify_all) {
       atomic_awaitable<int> aa(2);
       auto t =
         tmc::spawn_tuple(make_waiter(cv, aa), make_waiter(cv, aa)).fork();
-      waiter_count_accessor::wait_for_waiter_count(cv, 2);
+      co_await waiter_count_accessor::wait_for_waiter_count(cv, 2);
       EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
       EXPECT_EQ(aa.load(), 0);
       cv.ref()++;
@@ -221,7 +221,7 @@ TEST_F(CATEGORY, co_notify_all) {
       auto t = tmc::spawn_tuple(make_waiter(cv, aa), make_waiter(cv, aa))
                  .with_priority(1)
                  .fork();
-      waiter_count_accessor::wait_for_waiter_count(cv, 2);
+      co_await waiter_count_accessor::wait_for_waiter_count(cv, 2);
       EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
       EXPECT_EQ(aa.load(), 0);
       cv.ref()++;
@@ -239,7 +239,7 @@ TEST_F(CATEGORY, co_notify_no_symmetric) {
     tmc::atomic_condvar<int> cv(1);
     atomic_awaitable<int> aa(1);
     auto t = tmc::spawn(make_waiter(cv, aa)).with_priority(1).fork();
-    waiter_count_accessor::wait_for_waiter_count(cv, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(cv, 1);
     EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
     EXPECT_EQ(aa.load(), 0);
     EXPECT_EQ(tmc::current_priority(), 0);

--- a/tests/test_atomic_condvar.cpp
+++ b/tests/test_atomic_condvar.cpp
@@ -2,12 +2,12 @@
 #include "test_common.hpp"
 #include "tmc/atomic_condvar.hpp"
 #include "tmc/current.hpp"
+#include "waiter_count_accessor.hpp"
 
 #include <atomic>
 #include <gtest/gtest.h>
 
 #include <array>
-#include <thread>
 
 #define CATEGORY test_atomic_condvar
 
@@ -20,6 +20,8 @@ protected:
   static void TearDownTestSuite() { tmc::cpu_executor().teardown(); }
 
   static tmc::ex_cpu& ex() { return tmc::cpu_executor(); }
+
+  using waiter_count_accessor = tmc::tests::waiter_count_accessor;
 };
 
 static tmc::task<void>
@@ -65,7 +67,7 @@ TEST_F(CATEGORY, one_waiter) {
     tmc::atomic_condvar<int> cv(1);
     atomic_awaitable<int> aa(1);
     auto t = tmc::spawn(make_waiter(cv, aa)).fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(cv, 1);
     EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
     EXPECT_EQ(aa.load(), 0);
     cv.ref()++;
@@ -75,9 +77,6 @@ TEST_F(CATEGORY, one_waiter) {
   }());
 }
 
-// This specific test is kind of flaky on the CI runners, especially the MacOS
-// runner. The issue is not with the library, but if one of the threads gets
-// pre-empted for a while then the timed wait may not be long enough.
 TEST_F(CATEGORY, multi_waiter) {
   test_async_main(ex(), []() -> tmc::task<void> {
     tmc::atomic_condvar<int> cv(1);
@@ -87,16 +86,14 @@ TEST_F(CATEGORY, multi_waiter) {
       tasks[i] = make_waiter(cv, aa);
     }
     auto t = tmc::spawn_many(tasks).fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(cv, 5);
     EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
     EXPECT_EQ(aa.load(), 0);
     cv.ref()++;
     cv.notify_one();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    EXPECT_EQ(aa.load(), 1);
+    waiter_count_accessor::wait_for_waiter_count(cv, 4);
     cv.notify_n(2);
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    EXPECT_EQ(aa.load(), 3);
+    waiter_count_accessor::wait_for_waiter_count(cv, 2);
     cv.notify_all();
     co_await aa;
     EXPECT_EQ(aa.load(), 5);
@@ -110,7 +107,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
     std::optional<tmc::atomic_condvar<int>> cv;
     cv.emplace(1);
     auto t = tmc::spawn(make_waiter(*cv, aa)).fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(*cv, 1);
     EXPECT_EQ(aa.load(), 0);
 
     // Notify 0 waiters
@@ -125,7 +122,9 @@ TEST_F(CATEGORY, resume_in_destructor) {
     co_await cv->co_notify_one();
     co_await cv->co_notify_all();
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    // The value hasn't changed, so none of the notifies above should have
+    // woken the waiter. Verify it is still waiting.
+    EXPECT_EQ(waiter_count_accessor::waiter_count(*cv), 1u);
     EXPECT_EQ(aa.load(), 0);
 
     // Destroy cv while the task is still waiting.
@@ -141,7 +140,7 @@ TEST_F(CATEGORY, co_notify_one) {
       tmc::atomic_condvar<int> cv(1);
       atomic_awaitable<int> aa(1);
       auto t = tmc::spawn(make_waiter(cv, aa)).fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(cv, 1);
       EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
       EXPECT_EQ(aa.load(), 0);
       cv.ref()++;
@@ -158,7 +157,7 @@ TEST_F(CATEGORY, co_notify_one) {
       )
                  .with_priority(1)
                  .fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(cv, 1);
       EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
       EXPECT_EQ(aa.load(), 0);
       cv.ref()++;
@@ -176,7 +175,7 @@ TEST_F(CATEGORY, co_notify_n) {
       atomic_awaitable<int> aa(2);
       auto t =
         tmc::spawn_tuple(make_waiter(cv, aa), make_waiter(cv, aa)).fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(cv, 2);
       EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
       EXPECT_EQ(aa.load(), 0);
       cv.ref()++;
@@ -190,7 +189,7 @@ TEST_F(CATEGORY, co_notify_n) {
       auto t = tmc::spawn_tuple(make_waiter(cv, aa), make_waiter(cv, aa))
                  .with_priority(1)
                  .fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(cv, 2);
       EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
       EXPECT_EQ(aa.load(), 0);
       cv.ref()++;
@@ -208,7 +207,7 @@ TEST_F(CATEGORY, co_notify_all) {
       atomic_awaitable<int> aa(2);
       auto t =
         tmc::spawn_tuple(make_waiter(cv, aa), make_waiter(cv, aa)).fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(cv, 2);
       EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
       EXPECT_EQ(aa.load(), 0);
       cv.ref()++;
@@ -222,7 +221,7 @@ TEST_F(CATEGORY, co_notify_all) {
       auto t = tmc::spawn_tuple(make_waiter(cv, aa), make_waiter(cv, aa))
                  .with_priority(1)
                  .fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(cv, 2);
       EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
       EXPECT_EQ(aa.load(), 0);
       cv.ref()++;
@@ -240,7 +239,7 @@ TEST_F(CATEGORY, co_notify_no_symmetric) {
     tmc::atomic_condvar<int> cv(1);
     atomic_awaitable<int> aa(1);
     auto t = tmc::spawn(make_waiter(cv, aa)).with_priority(1).fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(cv, 1);
     EXPECT_EQ(cv.ref().load(std::memory_order_relaxed), 1);
     EXPECT_EQ(aa.load(), 0);
     EXPECT_EQ(tmc::current_priority(), 0);

--- a/tests/test_auto_reset_event.cpp
+++ b/tests/test_auto_reset_event.cpp
@@ -2,11 +2,11 @@
 #include "test_common.hpp"
 #include "tmc/auto_reset_event.hpp"
 #include "tmc/current.hpp"
+#include "waiter_count_accessor.hpp"
 
 #include <gtest/gtest.h>
 
 #include <array>
-#include <thread>
 
 #define CATEGORY test_auto_reset_event
 
@@ -19,6 +19,8 @@ protected:
   static void TearDownTestSuite() { tmc::cpu_executor().teardown(); }
 
   static tmc::ex_cpu& ex() { return tmc::cpu_executor(); }
+
+  using waiter_count_accessor = tmc::tests::waiter_count_accessor;
 };
 
 TEST_F(CATEGORY, no_waiters) {
@@ -84,7 +86,7 @@ TEST_F(CATEGORY, one_waiter) {
                  }(event, aa)
       )
                  .fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       event.set();
@@ -104,7 +106,7 @@ TEST_F(CATEGORY, one_waiter) {
                  }(event, aa)
       )
                  .fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       co_await event.co_set();
@@ -131,11 +133,10 @@ TEST_F(CATEGORY, multi_waiter) {
         }(event, aa);
       }
       auto t = tmc::spawn_many(tasks).fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(event, 5);
       EXPECT_EQ(aa.load(), 0);
       event.set();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      EXPECT_EQ(aa.load(), 1);
+      waiter_count_accessor::wait_for_waiter_count(event, 4);
       event.set();
       event.set();
       event.set();
@@ -163,11 +164,10 @@ TEST_F(CATEGORY, multi_waiter_co_set) {
         }(event, aa);
       }
       auto t = tmc::spawn_many(tasks).fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(event, 5);
       EXPECT_EQ(aa.load(), 0);
       co_await event.co_set();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
-      EXPECT_EQ(aa.load(), 1);
+      waiter_count_accessor::wait_for_waiter_count(event, 4);
       co_await event.co_set();
       co_await event.co_set();
       co_await event.co_set();
@@ -194,7 +194,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
                }(*event, aa)
     )
                .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(*event, 1);
     EXPECT_EQ(aa.load(), 0);
     EXPECT_EQ(event->is_set(), false);
     // Destroy event while the task is still waiting.
@@ -255,7 +255,7 @@ TEST_F(CATEGORY, co_set) {
                  }(event, aa)
       )
                  .fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       co_await event.co_set();
@@ -285,7 +285,7 @@ TEST_F(CATEGORY, co_set_no_symmetric) {
     )
                .with_priority(1)
                .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(event, 1);
     EXPECT_EQ(event.is_set(), false);
     EXPECT_EQ(aa.load(), 0);
     EXPECT_EQ(tmc::current_priority(), 0);

--- a/tests/test_auto_reset_event.cpp
+++ b/tests/test_auto_reset_event.cpp
@@ -86,7 +86,7 @@ TEST_F(CATEGORY, one_waiter) {
                  }(event, aa)
       )
                  .fork();
-      waiter_count_accessor::wait_for_waiter_count(event, 1);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       event.set();
@@ -106,7 +106,7 @@ TEST_F(CATEGORY, one_waiter) {
                  }(event, aa)
       )
                  .fork();
-      waiter_count_accessor::wait_for_waiter_count(event, 1);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       co_await event.co_set();
@@ -133,10 +133,10 @@ TEST_F(CATEGORY, multi_waiter) {
         }(event, aa);
       }
       auto t = tmc::spawn_many(tasks).fork();
-      waiter_count_accessor::wait_for_waiter_count(event, 5);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 5);
       EXPECT_EQ(aa.load(), 0);
       event.set();
-      waiter_count_accessor::wait_for_waiter_count(event, 4);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 4);
       event.set();
       event.set();
       event.set();
@@ -164,10 +164,10 @@ TEST_F(CATEGORY, multi_waiter_co_set) {
         }(event, aa);
       }
       auto t = tmc::spawn_many(tasks).fork();
-      waiter_count_accessor::wait_for_waiter_count(event, 5);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 5);
       EXPECT_EQ(aa.load(), 0);
       co_await event.co_set();
-      waiter_count_accessor::wait_for_waiter_count(event, 4);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 4);
       co_await event.co_set();
       co_await event.co_set();
       co_await event.co_set();
@@ -194,7 +194,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
                }(*event, aa)
     )
                .fork();
-    waiter_count_accessor::wait_for_waiter_count(*event, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(*event, 1);
     EXPECT_EQ(aa.load(), 0);
     EXPECT_EQ(event->is_set(), false);
     // Destroy event while the task is still waiting.
@@ -255,7 +255,7 @@ TEST_F(CATEGORY, co_set) {
                  }(event, aa)
       )
                  .fork();
-      waiter_count_accessor::wait_for_waiter_count(event, 1);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       co_await event.co_set();
@@ -285,7 +285,7 @@ TEST_F(CATEGORY, co_set_no_symmetric) {
     )
                .with_priority(1)
                .fork();
-    waiter_count_accessor::wait_for_waiter_count(event, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(event, 1);
     EXPECT_EQ(event.is_set(), false);
     EXPECT_EQ(aa.load(), 0);
     EXPECT_EQ(tmc::current_priority(), 0);

--- a/tests/test_barrier.cpp
+++ b/tests/test_barrier.cpp
@@ -138,7 +138,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
         }(*bar, aa)
       )
         .fork();
-    waiter_count_accessor::wait_for_waiter_count(*bar, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(*bar, 1);
     EXPECT_EQ(aa.load(), 0);
     // Destroy bar while the task is still waiting.
     bar.reset();

--- a/tests/test_barrier.cpp
+++ b/tests/test_barrier.cpp
@@ -1,18 +1,20 @@
 #include "atomic_awaitable.hpp"
 #include "test_common.hpp"
 #include "tmc/barrier.hpp"
+#include "waiter_count_accessor.hpp"
 
 #include <gtest/gtest.h>
 
 #include <atomic>
 #include <optional>
-#include <thread>
 #include <vector>
 
 #define CATEGORY test_barrier
 
 class CATEGORY : public testing::Test {
 protected:
+  using waiter_count_accessor = tmc::tests::waiter_count_accessor;
+
   static void SetUpTestSuite() {
     tmc::cpu_executor().set_thread_count(4).init();
   }
@@ -136,7 +138,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
         }(*bar, aa)
       )
         .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(*bar, 1);
     EXPECT_EQ(aa.load(), 0);
     // Destroy bar while the task is still waiting.
     bar.reset();

--- a/tests/test_latch.cpp
+++ b/tests/test_latch.cpp
@@ -1,18 +1,20 @@
 #include "atomic_awaitable.hpp"
 #include "test_common.hpp"
 #include "tmc/latch.hpp"
+#include "waiter_count_accessor.hpp"
 
 #include <gtest/gtest.h>
 
 #include <atomic>
 #include <optional>
-#include <thread>
 #include <vector>
 
 #define CATEGORY test_latch
 
 class CATEGORY : public testing::Test {
 protected:
+  using waiter_count_accessor = tmc::tests::waiter_count_accessor;
+
   static void SetUpTestSuite() {
     tmc::cpu_executor().set_thread_count(4).init();
   }
@@ -72,7 +74,7 @@ TEST_F(CATEGORY, once) {
         }(lat, aa)
       )
         .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(lat, 1);
     EXPECT_FALSE(lat.is_ready());
     EXPECT_EQ(aa.load(), 0);
     lat.count_down();
@@ -110,7 +112,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
         }(*lat, aa)
       )
         .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(*lat, 1);
     EXPECT_EQ(aa.load(), 0);
     // Destroy lat while the task is still waiting.
     lat.reset();

--- a/tests/test_latch.cpp
+++ b/tests/test_latch.cpp
@@ -74,7 +74,7 @@ TEST_F(CATEGORY, once) {
         }(lat, aa)
       )
         .fork();
-    waiter_count_accessor::wait_for_waiter_count(lat, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(lat, 1);
     EXPECT_FALSE(lat.is_ready());
     EXPECT_EQ(aa.load(), 0);
     lat.count_down();
@@ -112,7 +112,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
         }(*lat, aa)
       )
         .fork();
-    waiter_count_accessor::wait_for_waiter_count(*lat, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(*lat, 1);
     EXPECT_EQ(aa.load(), 0);
     // Destroy lat while the task is still waiting.
     lat.reset();

--- a/tests/test_manual_reset_event.cpp
+++ b/tests/test_manual_reset_event.cpp
@@ -80,7 +80,7 @@ TEST_F(CATEGORY, one_waiter) {
                  }(event, aa)
       )
                  .fork();
-      waiter_count_accessor::wait_for_waiter_count(event, 1);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       event.set();
@@ -99,7 +99,7 @@ TEST_F(CATEGORY, one_waiter) {
                  }(event, aa)
       )
                  .fork();
-      waiter_count_accessor::wait_for_waiter_count(event, 1);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       co_await event.co_set();
@@ -125,10 +125,10 @@ TEST_F(CATEGORY, multi_waiter) {
         }(event, aa);
       }
       auto t = tmc::spawn_many(tasks).fork();
-      waiter_count_accessor::wait_for_waiter_count(event, 5);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 5);
       EXPECT_EQ(aa.load(), 0);
       event.set();
-      waiter_count_accessor::wait_for_waiter_count(event, 0);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 0);
       co_await aa;
       EXPECT_EQ(aa.load(), 5);
       co_await std::move(t);
@@ -146,10 +146,10 @@ TEST_F(CATEGORY, multi_waiter) {
         }(event, aa);
       }
       auto t = tmc::spawn_many(tasks).fork();
-      waiter_count_accessor::wait_for_waiter_count(event, 5);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 5);
       EXPECT_EQ(aa.load(), 0);
       co_await event.co_set();
-      waiter_count_accessor::wait_for_waiter_count(event, 0);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 0);
       co_await aa;
       EXPECT_EQ(aa.load(), 5);
       co_await std::move(t);
@@ -172,7 +172,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
                }(*event, aa)
     )
                .fork();
-    waiter_count_accessor::wait_for_waiter_count(*event, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(*event, 1);
     EXPECT_EQ(aa.load(), 0);
     EXPECT_EQ(event->is_set(), false);
     // Destroy event while the task is still waiting.
@@ -207,7 +207,7 @@ TEST_F(CATEGORY, co_set) {
                  }(event, aa)
       )
                  .fork();
-      waiter_count_accessor::wait_for_waiter_count(event, 1);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       co_await event.co_set();
@@ -237,7 +237,7 @@ TEST_F(CATEGORY, co_set_no_symmetric) {
       )
                  .with_priority(1)
                  .fork();
-      waiter_count_accessor::wait_for_waiter_count(event, 1);
+      co_await waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       EXPECT_EQ(tmc::current_priority(), 0);

--- a/tests/test_manual_reset_event.cpp
+++ b/tests/test_manual_reset_event.cpp
@@ -2,11 +2,11 @@
 #include "test_common.hpp"
 #include "tmc/current.hpp"
 #include "tmc/manual_reset_event.hpp"
+#include "waiter_count_accessor.hpp"
 
 #include <gtest/gtest.h>
 
 #include <array>
-#include <thread>
 
 #define CATEGORY test_manual_reset_event
 
@@ -19,6 +19,8 @@ protected:
   static void TearDownTestSuite() { tmc::cpu_executor().teardown(); }
 
   static tmc::ex_cpu& ex() { return tmc::cpu_executor(); }
+
+  using waiter_count_accessor = tmc::tests::waiter_count_accessor;
 };
 
 TEST_F(CATEGORY, no_waiters) {
@@ -78,7 +80,7 @@ TEST_F(CATEGORY, one_waiter) {
                  }(event, aa)
       )
                  .fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       event.set();
@@ -97,7 +99,7 @@ TEST_F(CATEGORY, one_waiter) {
                  }(event, aa)
       )
                  .fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       co_await event.co_set();
@@ -123,10 +125,10 @@ TEST_F(CATEGORY, multi_waiter) {
         }(event, aa);
       }
       auto t = tmc::spawn_many(tasks).fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(event, 5);
       EXPECT_EQ(aa.load(), 0);
       event.set();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(event, 0);
       co_await aa;
       EXPECT_EQ(aa.load(), 5);
       co_await std::move(t);
@@ -144,10 +146,10 @@ TEST_F(CATEGORY, multi_waiter) {
         }(event, aa);
       }
       auto t = tmc::spawn_many(tasks).fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(event, 5);
       EXPECT_EQ(aa.load(), 0);
       co_await event.co_set();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(event, 0);
       co_await aa;
       EXPECT_EQ(aa.load(), 5);
       co_await std::move(t);
@@ -170,7 +172,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
                }(*event, aa)
     )
                .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(*event, 1);
     EXPECT_EQ(aa.load(), 0);
     EXPECT_EQ(event->is_set(), false);
     // Destroy event while the task is still waiting.
@@ -205,7 +207,7 @@ TEST_F(CATEGORY, co_set) {
                  }(event, aa)
       )
                  .fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       co_await event.co_set();
@@ -235,7 +237,7 @@ TEST_F(CATEGORY, co_set_no_symmetric) {
       )
                  .with_priority(1)
                  .fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(event, 1);
       EXPECT_EQ(event.is_set(), false);
       EXPECT_EQ(aa.load(), 0);
       EXPECT_EQ(tmc::current_priority(), 0);

--- a/tests/test_mutex.cpp
+++ b/tests/test_mutex.cpp
@@ -1,11 +1,11 @@
 #include "atomic_awaitable.hpp"
 #include "test_common.hpp"
 #include "tmc/mutex.hpp"
+#include "waiter_count_accessor.hpp"
 
 #include <gtest/gtest.h>
 
 #include <array>
-#include <thread>
 
 #define CATEGORY test_mutex
 
@@ -18,6 +18,8 @@ protected:
   static void TearDownTestSuite() { tmc::cpu_executor().teardown(); }
 
   static tmc::ex_cpu& ex() { return tmc::cpu_executor(); }
+
+  using waiter_count_accessor = tmc::tests::waiter_count_accessor;
 };
 
 TEST_F(CATEGORY, nonblocking) {
@@ -56,7 +58,7 @@ TEST_F(CATEGORY, one_waiter) {
         }(mut, aa)
       )
         .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(mut, 1);
     EXPECT_EQ(mut.is_locked(), true);
     EXPECT_EQ(aa.load(), 0);
     mut.unlock();
@@ -82,11 +84,10 @@ TEST_F(CATEGORY, multi_waiter) {
       }(mut, aa);
     }
     auto t = tmc::spawn_many(tasks).fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(mut, 5);
     EXPECT_EQ(mut.is_locked(), true);
     EXPECT_EQ(aa.load(), 0);
     mut.unlock();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     co_await aa;
     EXPECT_EQ(aa.load(), 5);
     co_await std::move(t);
@@ -107,7 +108,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
         }(*mut, aa)
       )
         .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(*mut, 1);
     EXPECT_EQ(aa.load(), 0);
     // Destroy mut while the task is still waiting.
     mut.reset();
@@ -131,11 +132,12 @@ TEST_F(CATEGORY, move_scope) {
       )
         .fork();
     {
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(*mut, 1);
       EXPECT_EQ(aa.load(), 0);
       auto s = *std::move(scope);
       scope.reset(); // should do nothing as the scope has been moved
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      // The mutex is still held (by s), so the waiter must remain suspended.
+      EXPECT_EQ(waiter_count_accessor::waiter_count(*mut), 1u);
       EXPECT_EQ(aa.load(), 0);
     }
     co_await aa;
@@ -187,7 +189,7 @@ TEST_F(CATEGORY, access_control_scope) {
         1000
       )
         .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(mut, 1000);
     mut.unlock();
     co_await std::move(ts);
     co_await mut;
@@ -216,7 +218,7 @@ TEST_F(CATEGORY, co_unlock) {
           }(mut, aa)
         )
           .fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(mut, 1);
       EXPECT_EQ(mut.is_locked(), true);
       EXPECT_EQ(aa.load(), 0);
       co_await mut.co_unlock();
@@ -244,7 +246,7 @@ TEST_F(CATEGORY, co_unlock_no_symmetric) {
       )
         .with_priority(1)
         .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(mut, 1);
     EXPECT_EQ(mut.is_locked(), true);
     EXPECT_EQ(aa.load(), 0);
     EXPECT_EQ(tmc::current_priority(), 0);

--- a/tests/test_mutex.cpp
+++ b/tests/test_mutex.cpp
@@ -58,7 +58,7 @@ TEST_F(CATEGORY, one_waiter) {
         }(mut, aa)
       )
         .fork();
-    waiter_count_accessor::wait_for_waiter_count(mut, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(mut, 1);
     EXPECT_EQ(mut.is_locked(), true);
     EXPECT_EQ(aa.load(), 0);
     mut.unlock();
@@ -84,7 +84,7 @@ TEST_F(CATEGORY, multi_waiter) {
       }(mut, aa);
     }
     auto t = tmc::spawn_many(tasks).fork();
-    waiter_count_accessor::wait_for_waiter_count(mut, 5);
+    co_await waiter_count_accessor::wait_for_waiter_count(mut, 5);
     EXPECT_EQ(mut.is_locked(), true);
     EXPECT_EQ(aa.load(), 0);
     mut.unlock();
@@ -108,7 +108,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
         }(*mut, aa)
       )
         .fork();
-    waiter_count_accessor::wait_for_waiter_count(*mut, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(*mut, 1);
     EXPECT_EQ(aa.load(), 0);
     // Destroy mut while the task is still waiting.
     mut.reset();
@@ -132,7 +132,7 @@ TEST_F(CATEGORY, move_scope) {
       )
         .fork();
     {
-      waiter_count_accessor::wait_for_waiter_count(*mut, 1);
+      co_await waiter_count_accessor::wait_for_waiter_count(*mut, 1);
       EXPECT_EQ(aa.load(), 0);
       auto s = *std::move(scope);
       scope.reset(); // should do nothing as the scope has been moved
@@ -189,7 +189,7 @@ TEST_F(CATEGORY, access_control_scope) {
         1000
       )
         .fork();
-    waiter_count_accessor::wait_for_waiter_count(mut, 1000);
+    co_await waiter_count_accessor::wait_for_waiter_count(mut, 1000);
     mut.unlock();
     co_await std::move(ts);
     co_await mut;
@@ -218,7 +218,7 @@ TEST_F(CATEGORY, co_unlock) {
           }(mut, aa)
         )
           .fork();
-      waiter_count_accessor::wait_for_waiter_count(mut, 1);
+      co_await waiter_count_accessor::wait_for_waiter_count(mut, 1);
       EXPECT_EQ(mut.is_locked(), true);
       EXPECT_EQ(aa.load(), 0);
       co_await mut.co_unlock();
@@ -246,7 +246,7 @@ TEST_F(CATEGORY, co_unlock_no_symmetric) {
       )
         .with_priority(1)
         .fork();
-    waiter_count_accessor::wait_for_waiter_count(mut, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(mut, 1);
     EXPECT_EQ(mut.is_locked(), true);
     EXPECT_EQ(aa.load(), 0);
     EXPECT_EQ(tmc::current_priority(), 0);

--- a/tests/test_semaphore.cpp
+++ b/tests/test_semaphore.cpp
@@ -87,7 +87,7 @@ TEST_F(CATEGORY, one_waiter) {
         }(sem, aa)
       )
         .fork();
-    waiter_count_accessor::wait_for_waiter_count(sem, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(sem, 1);
     EXPECT_EQ(sem.count(), 0);
     EXPECT_EQ(aa.load(), 0);
     sem.release();
@@ -109,11 +109,11 @@ TEST_F(CATEGORY, multi_waiter) {
       }(sem, aa);
     }
     auto t = tmc::spawn_many(tasks).fork();
-    waiter_count_accessor::wait_for_waiter_count(sem, 5);
+    co_await waiter_count_accessor::wait_for_waiter_count(sem, 5);
     EXPECT_EQ(sem.count(), 0);
     EXPECT_EQ(aa.load(), 0);
     sem.release(1);
-    waiter_count_accessor::wait_for_waiter_count(sem, 4);
+    co_await waiter_count_accessor::wait_for_waiter_count(sem, 4);
     sem.release(4);
     co_await aa;
     co_await std::move(t);
@@ -133,11 +133,11 @@ TEST_F(CATEGORY, multi_waiter_co_release) {
       }(sem, aa);
     }
     auto t = tmc::spawn_many(tasks).fork();
-    waiter_count_accessor::wait_for_waiter_count(sem, 5);
+    co_await waiter_count_accessor::wait_for_waiter_count(sem, 5);
     EXPECT_EQ(sem.count(), 0);
     EXPECT_EQ(aa.load(), 0);
     co_await sem.co_release();
-    waiter_count_accessor::wait_for_waiter_count(sem, 4);
+    co_await waiter_count_accessor::wait_for_waiter_count(sem, 4);
     co_await sem.co_release();
     co_await sem.co_release();
     co_await sem.co_release();
@@ -160,7 +160,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
         }(*sem, aa)
       )
         .fork();
-    waiter_count_accessor::wait_for_waiter_count(*sem, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(*sem, 1);
     EXPECT_EQ(aa.load(), 0);
     // Destroy sem while the task is still waiting.
     sem.reset();
@@ -184,7 +184,7 @@ TEST_F(CATEGORY, move_scope) {
       )
         .fork();
     {
-      waiter_count_accessor::wait_for_waiter_count(*sem, 1);
+      co_await waiter_count_accessor::wait_for_waiter_count(*sem, 1);
       EXPECT_EQ(aa.load(), 0);
       auto s = *std::move(scope);
       scope.reset(); // should do nothing as the scope has been moved
@@ -242,7 +242,7 @@ TEST_F(CATEGORY, access_control_scope) {
         1000
       )
         .fork();
-    waiter_count_accessor::wait_for_waiter_count(sem, 1000);
+    co_await waiter_count_accessor::wait_for_waiter_count(sem, 1000);
     sem.release();
     co_await std::move(ts);
     co_await sem;
@@ -272,7 +272,7 @@ TEST_F(CATEGORY, co_release) {
                  }(sem, aa)
       )
                  .fork();
-      waiter_count_accessor::wait_for_waiter_count(sem, 1);
+      co_await waiter_count_accessor::wait_for_waiter_count(sem, 1);
       EXPECT_EQ(sem.count(), 0);
       EXPECT_EQ(aa.load(), 0);
       co_await sem.co_release();
@@ -299,7 +299,7 @@ TEST_F(CATEGORY, co_release_no_symmetric) {
       )
         .with_priority(1)
         .fork();
-    waiter_count_accessor::wait_for_waiter_count(sem, 1);
+    co_await waiter_count_accessor::wait_for_waiter_count(sem, 1);
     EXPECT_EQ(sem.count(), 0);
     EXPECT_EQ(aa.load(), 0);
     EXPECT_EQ(tmc::current_priority(), 0);

--- a/tests/test_semaphore.cpp
+++ b/tests/test_semaphore.cpp
@@ -3,16 +3,18 @@
 #include "tmc/current.hpp"
 #include "tmc/semaphore.hpp"
 #include "tmc/utils.hpp"
+#include "waiter_count_accessor.hpp"
 
 #include <gtest/gtest.h>
 
 #include <array>
-#include <thread>
 
 #define CATEGORY test_semaphore
 
 class CATEGORY : public testing::Test {
 protected:
+  using waiter_count_accessor = tmc::tests::waiter_count_accessor;
+
   static void SetUpTestSuite() {
     tmc::cpu_executor().set_thread_count(4).set_priority_count(2).init();
   }
@@ -85,7 +87,7 @@ TEST_F(CATEGORY, one_waiter) {
         }(sem, aa)
       )
         .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(sem, 1);
     EXPECT_EQ(sem.count(), 0);
     EXPECT_EQ(aa.load(), 0);
     sem.release();
@@ -107,12 +109,11 @@ TEST_F(CATEGORY, multi_waiter) {
       }(sem, aa);
     }
     auto t = tmc::spawn_many(tasks).fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(sem, 5);
     EXPECT_EQ(sem.count(), 0);
     EXPECT_EQ(aa.load(), 0);
     sem.release(1);
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    EXPECT_EQ(aa.load(), 1);
+    waiter_count_accessor::wait_for_waiter_count(sem, 4);
     sem.release(4);
     co_await aa;
     co_await std::move(t);
@@ -132,12 +133,11 @@ TEST_F(CATEGORY, multi_waiter_co_release) {
       }(sem, aa);
     }
     auto t = tmc::spawn_many(tasks).fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(sem, 5);
     EXPECT_EQ(sem.count(), 0);
     EXPECT_EQ(aa.load(), 0);
     co_await sem.co_release();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    EXPECT_EQ(aa.load(), 1);
+    waiter_count_accessor::wait_for_waiter_count(sem, 4);
     co_await sem.co_release();
     co_await sem.co_release();
     co_await sem.co_release();
@@ -160,7 +160,7 @@ TEST_F(CATEGORY, resume_in_destructor) {
         }(*sem, aa)
       )
         .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(*sem, 1);
     EXPECT_EQ(aa.load(), 0);
     // Destroy sem while the task is still waiting.
     sem.reset();
@@ -184,11 +184,13 @@ TEST_F(CATEGORY, move_scope) {
       )
         .fork();
     {
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(*sem, 1);
       EXPECT_EQ(aa.load(), 0);
       auto s = *std::move(scope);
       scope.reset(); // should do nothing as the scope has been moved
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      // The semaphore is still held (by s), so the waiter must remain
+      // suspended.
+      EXPECT_EQ(waiter_count_accessor::waiter_count(*sem), 1u);
       EXPECT_EQ(aa.load(), 0);
     }
     co_await aa;
@@ -240,7 +242,7 @@ TEST_F(CATEGORY, access_control_scope) {
         1000
       )
         .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(sem, 1000);
     sem.release();
     co_await std::move(ts);
     co_await sem;
@@ -270,7 +272,7 @@ TEST_F(CATEGORY, co_release) {
                  }(sem, aa)
       )
                  .fork();
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      waiter_count_accessor::wait_for_waiter_count(sem, 1);
       EXPECT_EQ(sem.count(), 0);
       EXPECT_EQ(aa.load(), 0);
       co_await sem.co_release();
@@ -297,7 +299,7 @@ TEST_F(CATEGORY, co_release_no_symmetric) {
       )
         .with_priority(1)
         .fork();
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    waiter_count_accessor::wait_for_waiter_count(sem, 1);
     EXPECT_EQ(sem.count(), 0);
     EXPECT_EQ(aa.load(), 0);
     EXPECT_EQ(tmc::current_priority(), 0);

--- a/tests/waiter_count_accessor.hpp
+++ b/tests/waiter_count_accessor.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <thread>
+
+namespace tmc::tests {
+
+// Helper class for accessing the private `waiter_count()` method on TMC
+// synchronization primitives. The primitives friend this class so tests can
+// observe waiter counts without exposing the API publicly.
+class waiter_count_accessor {
+public:
+  // Access wrapper for the primitive's private waiter_count().
+  template <typename Primitive> static size_t waiter_count(Primitive& P) {
+    return P.waiter_count();
+  }
+
+  // Polls until the primitive's waiter_count() equals Expected. Used in
+  // place of fixed std::this_thread::sleep_for waits, which are not reliable
+  // on loaded CI runners.
+  template <typename Primitive>
+  static void wait_for_waiter_count(Primitive& P, size_t Expected) {
+    while (P.waiter_count() != Expected) {
+      std::this_thread::sleep_for(std::chrono::microseconds(100));
+    }
+  }
+};
+
+} // namespace tmc::tests

--- a/tests/waiter_count_accessor.hpp
+++ b/tests/waiter_count_accessor.hpp
@@ -22,7 +22,7 @@ public:
   template <typename Primitive>
   static void wait_for_waiter_count(Primitive& P, size_t Expected) {
     while (P.waiter_count() != Expected) {
-      std::this_thread::sleep_for(std::chrono::microseconds(100));
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
   }
 };

--- a/tests/waiter_count_accessor.hpp
+++ b/tests/waiter_count_accessor.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "tmc/aw_yield.hpp"
+#include "tmc/task.hpp"
 #include <chrono>
 #include <cstddef>
 #include <thread>
@@ -20,8 +22,18 @@ public:
   // place of fixed std::this_thread::sleep_for waits, which are not reliable
   // on loaded CI runners.
   template <typename Primitive>
-  static void wait_for_waiter_count(Primitive& P, size_t Expected) {
-    while (P.waiter_count() != Expected) {
+  static tmc::task<void> wait_for_waiter_count(Primitive& P, size_t Expected) {
+    while (true) {
+      // alternate between reschedule() if running on the same thread and sleep
+      // if waiting for another thread
+      if (P.waiter_count() == Expected) {
+        break;
+      }
+      co_await tmc::reschedule();
+
+      if (P.waiter_count() == Expected) {
+        break;
+      }
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
   }


### PR DESCRIPTION
These tests used to wait 10 ms for waiters to be registered with the data structures. This was a problem on very slow / overloaded CI runners (typically the Mac runner) where the other thread may not actually run in 10ms in which case the test would proceed without the waiter being registered. This sleep was required because there was no way offered by the library to actually guarantee that a waiter had been registered.

Now we can use the internal-only function waiter_count() and poll until the waiter is actually registered, making these tests reliable.

Goes with https://github.com/tzcnt/TooManyCooks/pull/230