### PR TITLE
use `tmc::qu_unbounded_spsc` in pipeline_fifo example

### DIFF
--- a/examples/pipeline.cpp
+++ b/examples/pipeline.cpp
@@ -12,12 +12,12 @@
 #include "tmc/semaphore.hpp"
 #include "tmc/task.hpp"
 
-// // This pipeline may process tasks out of order. For a FIFO pipeline,
-// // include pipeline_fifo.hpp instead.
-// #include "pipeline.hpp"
+// This pipeline may process tasks out of order. For a FIFO pipeline,
+// include pipeline_fifo.hpp instead.
+#include "pipeline.hpp"
 
-// Strictly FIFO pipeline implementation
-#include "pipeline_fifo.hpp"
+// // Strictly FIFO pipeline implementation
+// #include "pipeline_fifo.hpp"
 
 #include <chrono>
 #include <cstdio>

--- a/examples/pipeline.cpp
+++ b/examples/pipeline.cpp
@@ -7,18 +7,17 @@
 // This is just the user application.
 // The generic implementation is in "pipeline.hpp" or "pipeline_fifo.hpp".
 
-#include "tmc/channel.hpp"
 #include "tmc/ex_cpu.hpp"
 #include "tmc/fork_group.hpp"
 #include "tmc/semaphore.hpp"
 #include "tmc/task.hpp"
 
-// This pipeline may process tasks out of order. For a FIFO pipeline,
-// include pipeline_fifo.hpp instead.
-#include "pipeline.hpp"
+// // This pipeline may process tasks out of order. For a FIFO pipeline,
+// // include pipeline_fifo.hpp instead.
+// #include "pipeline.hpp"
 
-// // Strictly FIFO pipeline implementation
-// #include "pipeline_fifo.hpp"
+// Strictly FIFO pipeline implementation
+#include "pipeline_fifo.hpp"
 
 #include <chrono>
 #include <cstdio>
@@ -55,7 +54,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]) {
     // Track all pipeline stage workers here so we can cleanly join at the end
     auto fg = tmc::fork_group();
 
-    auto in = tmc::make_channel<int>();
+    auto in = make_pipeline_queue<int>();
     tmc::semaphore inputSem(0);
     auto first = start_pipeline(fg, in, &inputSem, plus_half, 10);
     auto second = pipeline_transform(fg, first, times_two, 10);
@@ -84,9 +83,12 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]) {
       for (int i = 0; i < NELEMS; ++i) {
         // Also apply backpressure to the input to avoid overloading the queue
         co_await inputSem;
-        in.post(i);
+        in->post(i);
       }
-      co_await in.drain();
+      // Close the input queue. The first stage worker will drain remaining
+      // items and then close its output queue, propagating closure through
+      // the pipeline. Awaiting the fork_group below ensures full drain.
+      in->close();
     }
 
     co_await std::move(fg);

--- a/examples/pipeline.hpp
+++ b/examples/pipeline.hpp
@@ -7,6 +7,9 @@
 // This pipeline may process tasks out of order. For a FIFO pipeline, see
 // pipeline_fifo.cpp.
 
+// This pipeline uses tmc::channel (MPMC) since each stage may have multiple
+// concurrent workers reading from the input channel.
+
 #include "tmc/channel.hpp"
 #include "tmc/fork_group.hpp"
 #include "tmc/semaphore.hpp"
@@ -16,6 +19,31 @@
 
 #include <cstddef>
 #include <type_traits>
+#include <utility>
+
+// pipeline_queue_ptr is a thin wrapper around tmc::chan_tok that exposes the
+// same arrow-style API (->post() / ->close()) as the FIFO pipeline's
+// shared_ptr<qu_unbounded_spsc<T>>. tmc::chan_tok already owns a shared_ptr
+// to the underlying channel and carries per-thread hazard-pointer state, so
+// there is no need to add another shared_ptr layer; copying the wrapper
+// copies the chan_tok, producing an independent token that refers to the
+// same channel.
+template <typename T> class pipeline_queue_ptr {
+  tmc::chan_tok<T> tok_;
+
+public:
+  explicit pipeline_queue_ptr(tmc::chan_tok<T> Tok) noexcept
+      : tok_(std::move(Tok)) {}
+
+  operator tmc::chan_tok<T>() { return tok_; }
+
+  tmc::chan_tok<T>* operator->() noexcept { return &tok_; }
+  tmc::chan_tok<T>& operator*() noexcept { return tok_; }
+};
+
+template <typename T> pipeline_queue_ptr<T> make_pipeline_queue() {
+  return pipeline_queue_ptr<T>(tmc::make_channel<T>());
+}
 
 template <typename Input, typename Output, typename ProcessFunc>
 struct pipeline_stage {
@@ -52,7 +80,7 @@ struct pipeline_stage {
     tmc::aw_fork_group<0, void>& fg, tmc::chan_tok<Input> inChan,
     tmc::semaphore* inSem, ProcessFunc func, size_t workerCount
   )
-      : outChan_(tmc::make_channel<Output>()),
+      : outChan_(make_pipeline_queue<Output>()),
         // Initialize our output semaphore to 0. The next stage will set this
         // semaphore capacity (for their input channel) based on their worker
         // count.
@@ -65,12 +93,13 @@ struct pipeline_stage {
 
     auto sg = tmc::spawn_group();
     for (size_t i = 0; i < workerCount; ++i) {
+      // Each worker receives its own independent token (via chan_tok copy).
       sg.add(worker(inChan, inSem, outChan_, &outSem_, func));
     }
 
     // Create a task that automatically closes and drains the output channel
-    // after all of the workers finish.
-    fg.fork([](auto SG, auto Chan) -> tmc::task<void> {
+    // after all of the workers finish. It also gets its own token copy.
+    fg.fork([](auto SG, tmc::chan_tok<Output> Chan) -> tmc::task<void> {
       co_await std::move(SG);
       co_await Chan.drain(); // implicitly closes the channel
     }(std::move(sg), outChan_));
@@ -105,6 +134,7 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
 
     auto sg = tmc::spawn_group();
     for (size_t i = 0; i < workerCount; ++i) {
+      // Each worker receives its own independent token (via chan_tok copy).
       sg.add(worker(inChan, inSem, func));
     }
 
@@ -114,7 +144,7 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
 
 template <typename Input, typename Func>
 auto start_pipeline(
-  tmc::aw_fork_group<0, void>& fg, tmc::chan_tok<Input> from,
+  tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> from,
   tmc::semaphore* inSem, Func transformFunc, size_t workerCount = 1
 ) {
   using Intermediate = std::invoke_result_t<Func, Input&&>;

--- a/examples/pipeline.hpp
+++ b/examples/pipeline.hpp
@@ -23,11 +23,7 @@
 
 // pipeline_queue_ptr is a thin wrapper around tmc::chan_tok that exposes the
 // same arrow-style API (->post() / ->close()) as the FIFO pipeline's
-// shared_ptr<qu_unbounded_spsc<T>>. tmc::chan_tok already owns a shared_ptr
-// to the underlying channel and carries per-thread hazard-pointer state, so
-// there is no need to add another shared_ptr layer; copying the wrapper
-// copies the chan_tok, producing an independent token that refers to the
-// same channel.
+// shared_ptr<qu_unbounded_spsc<T>>.
 template <typename T> class pipeline_queue_ptr {
   tmc::chan_tok<T> tok_;
 

--- a/examples/pipeline_fifo.hpp
+++ b/examples/pipeline_fifo.hpp
@@ -5,31 +5,32 @@
 // - Automatic backpressure based on the current stage parallelism
 
 // This pipeline implements guaranteed FIFO processing throughout. Each stage
-// has a single main worker that awaits data from the prior stage's channel, and
+// has a single main worker that awaits data from the prior stage's queue, and
 // forks a new task worker to handle the processing of the next stage. A handle
-// to this forked task is placed into the next stage's input channel. This
+// to this forked task is placed into the next stage's input queue. This
 // allows multiple forked workers to execute in parallel, but the next stage
 // will only retrieve results in the order they were originally submitted.
 
 // Since forked tasks are non-movable this uses the with_result_of trick to
-// construct them directly into channel storage, and consumers access the
-// channel using the pull_zc() zero-copy read function.
+// construct them directly into queue storage, and consumers access the
+// queue using the pull() zero-copy read function.
 
 // One quirk of this implementation is that the final consumer must also read
-// results by co_awaiting the output of pull_zc().
+// results by co_awaiting the output of pull().
 
-#include "tmc/channel.hpp"
 #include "tmc/fork_group.hpp"
+#include "tmc/qu_unbounded_mpsc.hpp"
 #include "tmc/semaphore.hpp"
 #include "tmc/spawn.hpp"
 #include "tmc/task.hpp"
 #include "tmc/traits.hpp"
 
 #include <cstddef>
+#include <memory>
 #include <type_traits>
 
 // Required to allow constructing the non-movable type tmc::aw_spawn_fork
-// directly into the channel storage
+// directly into the queue storage
 // https://quuxplusone.github.io/blog/2018/05/17/super-elider-round-2/
 template <class F> class with_result_of_t {
   F&& fun;
@@ -44,44 +45,56 @@ template <class F> inline with_result_of_t<F> with_result_of(F&& f) {
   return with_result_of_t<F>(std::forward<F>(f));
 }
 
+// qu_unbounded_mpsc is non-movable and non-copyable, so we share it via
+// shared_ptr to keep it alive for the lifetime of all producers and the
+// single consumer.
+template <typename T> using pipeline_queue = tmc::qu_unbounded_mpsc<T>;
+template <typename T>
+using pipeline_queue_ptr = std::shared_ptr<pipeline_queue<T>>;
+
+template <typename T> pipeline_queue_ptr<T> make_pipeline_queue() {
+  return std::make_shared<pipeline_queue<T>>();
+}
+
 template <typename Input, typename Output, typename ProcessFunc, bool End>
 struct pipeline_stage {
-  // The output channel contains forked task handles - this is how we manage
+  // The output queue contains forked task handles - this is how we manage
   // parallelism while ensuring FIFO ordering.
   using output_t = tmc::aw_spawn_fork<tmc::task<Output>>;
 
-  tmc::chan_tok<output_t> outChan_;
+  pipeline_queue_ptr<output_t> outChan_;
   tmc::semaphore outSem_;
 
   template <typename CInput>
   static tmc::task<void> worker(
-    tmc::chan_tok<CInput> inChan, tmc::semaphore* inSem,
-    tmc::chan_tok<output_t> outChan, tmc::semaphore* outSem, ProcessFunc func
+    pipeline_queue_ptr<CInput> inChan, tmc::semaphore* inSem,
+    pipeline_queue_ptr<output_t> outChan, tmc::semaphore* outSem,
+    ProcessFunc func
   ) {
-    while (auto input = co_await inChan.pull_zc()) {
+    while (auto input = co_await inChan->pull()) {
       if (inSem != nullptr) {
         inSem->release();
       }
 
       // Wait for the output semaphore so we can construct the data directly in
-      // the output channel
+      // the output queue
       if (outSem != nullptr) {
         co_await *outSem;
       }
 
       if constexpr (tmc::traits::is_awaitable<CInput>) {
-        auto data = co_await std::move(input->get());
+        auto data = co_await std::move(input.get());
         using FInput = tmc::traits::awaitable_result_t<CInput>;
-        // The data element in the channel is an awaitable
+        // The data element in the queue is an awaitable
         if constexpr (tmc::traits::is_awaitable<
                         std::invoke_result_t<ProcessFunc, FInput&&>>) {
           // ProcessFunc is a coroutine
-          outChan.post(with_result_of([&]() {
+          outChan->post(with_result_of([&]() {
             return tmc::spawn(func(std::move(data))).fork();
           }));
         } else {
           // ProcessFunc is a regular function
-          outChan.post(with_result_of([&]() {
+          outChan->post(with_result_of([&]() {
             return tmc::spawn([](ProcessFunc f, FInput i) -> tmc::task<Output> {
                      co_return f(std::move(i));
                    }(func, std::move(data)))
@@ -90,37 +103,41 @@ struct pipeline_stage {
         }
       } else {
         using FInput = CInput;
-        // The data element in the channel is a value
+        // The data element in the queue is a value
         if constexpr (tmc::traits::is_awaitable<
                         std::invoke_result_t<ProcessFunc, FInput&&>>) {
           // ProcessFunc is a coroutine
-          outChan.post(with_result_of([&]() {
-            return tmc::spawn(func(std::move(input->get()))).fork();
+          outChan->post(with_result_of([&]() {
+            return tmc::spawn(func(std::move(input.get()))).fork();
           }));
         } else {
           // ProcessFunc is a regular function
-          outChan.post(with_result_of([&]() {
+          outChan->post(with_result_of([&]() {
             return tmc::spawn([](ProcessFunc f, FInput i) -> tmc::task<Output> {
                      co_return f(std::move(i));
-                   }(func, std::move(input->get())))
+                   }(func, std::move(input.get())))
               .fork();
           }));
         }
       }
     }
+
+    // Input queue is closed and drained. Close the output queue so the
+    // downstream stage knows no more elements are coming.
+    outChan->close();
   }
 
   pipeline_stage(
-    tmc::aw_fork_group<0, void>& fg, tmc::chan_tok<Input> inChan,
+    tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> inChan,
     tmc::semaphore* inSem, ProcessFunc func, size_t parallelism
   )
-      : outChan_(tmc::make_channel<tmc::aw_spawn_fork<tmc::task<Output>>>()),
+      : outChan_(make_pipeline_queue<output_t>()),
         // Initialize our output semaphore to 0. The next stage will set this
-        // semaphore capacity (for their input channel) based on their worker
+        // semaphore capacity (for their input queue) based on their worker
         // count.
         outSem_(tmc::semaphore(0)) {
 
-    // Set our input channel capacity to 2x our worker count.
+    // Set our input queue capacity to 2x our worker count.
     if (inSem != nullptr) {
       inSem->release(2 * parallelism);
     }
@@ -130,20 +147,15 @@ struct pipeline_stage {
       outSem = nullptr;
     }
 
-    // Create a task that automatically closes and drains the output channel
-    // after all of the workers finish.
-    fg.fork([](tmc::task<void> T, auto Chan) -> tmc::task<void> {
-      co_await std::move(T);
-      co_await Chan.drain(); // implicitly closes the channel
-    }(worker(inChan, inSem, outChan_, outSem, func), outChan_));
+    fg.fork(worker(inChan, inSem, outChan_, outSem, func));
   }
 
-  tmc::chan_tok<output_t> get_channel() { return outChan_; }
+  pipeline_queue_ptr<output_t> get_channel() { return outChan_; }
 };
 
 template <typename Input, typename Func>
 auto start_pipeline(
-  tmc::aw_fork_group<0, void>& fg, tmc::chan_tok<Input> from,
+  tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> from,
   tmc::semaphore* inSem, Func transformFunc, size_t parallelism = 1
 ) {
   using Intermediate = std::invoke_result_t<Func, Input&&>;
@@ -176,13 +188,13 @@ auto pipeline_transform(
 template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
   template <typename CInput>
   static tmc::task<void> worker(
-    tmc::chan_tok<CInput> inChan, tmc::semaphore* inSem, ProcessFunc func
+    pipeline_queue_ptr<CInput> inChan, tmc::semaphore* inSem, ProcessFunc func
   ) {
-    while (auto input = co_await inChan.pull_zc()) {
+    while (auto input = co_await inChan->pull()) {
       inSem->release();
 
       if constexpr (tmc::traits::is_awaitable<CInput>) {
-        auto data = co_await std::move(input->get());
+        auto data = co_await std::move(input.get());
         using FInput = tmc::traits::awaitable_result_t<CInput>;
         if constexpr (tmc::traits::is_awaitable<
                         std::invoke_result_t<ProcessFunc, FInput&&>>) {
@@ -194,19 +206,19 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
         using FInput = CInput;
         if constexpr (tmc::traits::is_awaitable<
                         std::invoke_result_t<ProcessFunc, FInput&&>>) {
-          co_await func(std::move(input->get()));
+          co_await func(std::move(input.get()));
         } else {
-          func(std::move(input->get()));
+          func(std::move(input.get()));
         }
       }
     }
   }
 
   pipeline_end_stage(
-    tmc::aw_fork_group<0, void>& fg, tmc::chan_tok<Input> inChan,
+    tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> inChan,
     tmc::semaphore* inSem, ProcessFunc func, size_t parallelism
   ) {
-    // Set our input channel capacity to 2x our worker count.
+    // Set our input queue capacity to 2x our worker count.
     inSem->release(2 * parallelism);
 
     fg.fork(worker(inChan, inSem, func));

--- a/examples/pipeline_fifo.hpp
+++ b/examples/pipeline_fifo.hpp
@@ -19,7 +19,7 @@
 // results by co_awaiting the output of pull().
 
 #include "tmc/fork_group.hpp"
-#include "tmc/qu_unbounded_mpsc.hpp"
+#include "tmc/qu_unbounded_spsc.hpp"
 #include "tmc/semaphore.hpp"
 #include "tmc/spawn.hpp"
 #include "tmc/task.hpp"
@@ -45,10 +45,10 @@ template <class F> inline with_result_of_t<F> with_result_of(F&& f) {
   return with_result_of_t<F>(std::forward<F>(f));
 }
 
-// qu_unbounded_mpsc is non-movable and non-copyable, so we share it via
-// shared_ptr to keep it alive for the lifetime of all producers and the
+// qu_unbounded_spsc is non-movable and non-copyable, so we share it via
+// shared_ptr to keep it alive for the lifetime of the single producer and
 // single consumer.
-template <typename T> using pipeline_queue = tmc::qu_unbounded_mpsc<T>;
+template <typename T> using pipeline_queue = tmc::qu_unbounded_spsc<T>;
 template <typename T>
 using pipeline_queue_ptr = std::shared_ptr<pipeline_queue<T>>;
 


### PR DESCRIPTION
This example links together a sequence of actors by using forked tasks in between to maintain concurrency. So only SPSC queue is required. This gives a ~20% performance improvement over the old tmc::channel-based implementation.