### PR TITLE
tests for qu_bounded_spsc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,10 @@ make_exe(pipeline
     examples/pipeline.cpp
 )
 
+make_exe(pipeline_fifo
+    examples/pipeline_fifo.cpp
+)
+
 make_exe(asio_prio
     examples/asio/prio.cpp
 )

--- a/examples/pipeline.hpp
+++ b/examples/pipeline.hpp
@@ -19,27 +19,6 @@
 
 #include <cstddef>
 #include <type_traits>
-#include <utility>
-
-// pipeline_queue_ptr is a thin wrapper around tmc::chan_tok that exposes the
-// same arrow-style API (->post() / ->close()) as the FIFO pipeline's
-// shared_ptr<qu_unbounded_spsc<T>>.
-template <typename T> class pipeline_queue_ptr {
-  tmc::chan_tok<T> tok_;
-
-public:
-  explicit pipeline_queue_ptr(tmc::chan_tok<T> Tok) noexcept
-      : tok_(std::move(Tok)) {}
-
-  operator tmc::chan_tok<T>() { return tok_; }
-
-  tmc::chan_tok<T>* operator->() noexcept { return &tok_; }
-  tmc::chan_tok<T>& operator*() noexcept { return tok_; }
-};
-
-template <typename T> pipeline_queue_ptr<T> make_pipeline_queue() {
-  return pipeline_queue_ptr<T>(tmc::make_channel<T>());
-}
 
 template <typename Input, typename Output, typename ProcessFunc>
 struct pipeline_stage {
@@ -76,7 +55,7 @@ struct pipeline_stage {
     tmc::aw_fork_group<0, void>& fg, tmc::chan_tok<Input> inChan,
     tmc::semaphore* inSem, ProcessFunc func, size_t workerCount
   )
-      : outChan_(make_pipeline_queue<Output>()),
+      : outChan_(tmc::make_channel<Output>()),
         // Initialize our output semaphore to 0. The next stage will set this
         // semaphore capacity (for their input channel) based on their worker
         // count.
@@ -95,7 +74,7 @@ struct pipeline_stage {
 
     // Create a task that automatically closes and drains the output channel
     // after all of the workers finish. It also gets its own token copy.
-    fg.fork([](auto SG, tmc::chan_tok<Output> Chan) -> tmc::task<void> {
+    fg.fork([](auto SG, auto Chan) -> tmc::task<void> {
       co_await std::move(SG);
       co_await Chan.drain(); // implicitly closes the channel
     }(std::move(sg), outChan_));
@@ -140,7 +119,7 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
 
 template <typename Input, typename Func>
 auto start_pipeline(
-  tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> from,
+  tmc::aw_fork_group<0, void>& fg, tmc::chan_tok<Input> from,
   tmc::semaphore* inSem, Func transformFunc, size_t workerCount = 1
 ) {
   using Intermediate = std::invoke_result_t<Func, Input&&>;

--- a/examples/pipeline_fifo.cpp
+++ b/examples/pipeline_fifo.cpp
@@ -3,18 +3,15 @@
 // - Configurable number of stages / input / output types
 // - Configurable parallelism per stage
 // - Automatic backpressure based on the current stage parallelism
-
-// This pipeline may process tasks out of order. For a FIFO pipeline,
-// see pipeline_fifo.cpp.
+// - Parallel processing of inputs with FIFO serialization of outputs
 
 #include "tmc/ex_cpu.hpp"
 #include "tmc/fork_group.hpp"
-#include "tmc/semaphore.hpp"
 #include "tmc/task.hpp"
 
 // This is just the user application.
-// The generic pipeline implementation is in the header
-#include "pipeline.hpp"
+// The generic FIFO pipeline implementation is in the header
+#include "pipeline_fifo.hpp"
 
 #include <chrono>
 #include <cstdio>
@@ -51,9 +48,11 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]) {
     // Track all pipeline stage workers here so we can cleanly join at the end
     auto fg = tmc::fork_group();
 
-    auto in = tmc::make_channel<int>();
-    tmc::semaphore inputSem(0);
-    auto first = start_pipeline(fg, in, &inputSem, plus_half, 10);
+    // Each stage owns its own output queue, sized to that stage's parallelism
+    // parameter. The bounded output queue provides backpressure and gates the
+    // stage's own in-flight parallelism. The start stage additionally owns
+    // its input queue (the queue the driver posts to), exposed as `.in`.
+    auto first = start_pipeline<int>(fg, plus_half, 10);
     auto second = pipeline_transform(fg, first, times_two, 10);
     auto third = pipeline_transform(fg, second, minus_one, 10);
     auto fourth = pipeline_transform(fg, third, as_bool, 10);
@@ -61,13 +60,15 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]) {
     size_t sum = 0;
     size_t count = 0;
 
-    // The final stage serializes all the results with workerCount = 1
-    // So it's the bottleneck in this pipeline design
+    // This final stage has been configured to serialize the results by setting
+    // parallelism = 1. Results will appear in the same order as the original
+    // input. Another option would be to consume the results directly from the
+    // prior stage's get_channel().
     [[maybe_unused]] auto fifth = end_pipeline(
       fg, fourth,
       [&sum, &count](bool i) {
         sum += static_cast<size_t>(i);
-        ++count;
+        count += 1;
       },
       1
     );
@@ -78,11 +79,14 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]) {
       // Run the initial producer task inline. Optionally, this could also be
       // added to the fg.
       for (int i = 0; i < NELEMS; ++i) {
-        // Also apply backpressure to the input to avoid overloading the queue
-        co_await inputSem;
-        in.post(i);
+        // The bounded queue's post() suspends when the queue is full,
+        // providing backpressure to the producer.
+        co_await first.in->post(i);
       }
-      co_await in.drain();
+      // Close the input queue. The first stage worker will drain remaining
+      // items and then close its output queue, propagating closure through
+      // the pipeline. Awaiting the fork_group below ensures full drain.
+      first.in->close();
     }
 
     co_await std::move(fg);

--- a/examples/pipeline_fifo.hpp
+++ b/examples/pipeline_fifo.hpp
@@ -18,9 +18,15 @@
 // One quirk of this implementation is that the final consumer must also read
 // results by co_awaiting the output of pull().
 
+// Each stage owns its own output queue, sized to that stage's parallelism
+// parameter. The bounded output queue gates the stage's own in-flight
+// parallelism: when the queue is full, the stage's worker blocks on post(),
+// preventing it from forking more work than `parallelism` items at a time.
+// The start stage owns its input queue (the queue the driver posts to) in
+// addition to its output queue, and exposes it as the public `in` member.
+
 #include "tmc/fork_group.hpp"
-#include "tmc/qu_unbounded_spsc.hpp"
-#include "tmc/semaphore.hpp"
+#include "tmc/qu_bounded_spsc.hpp"
 #include "tmc/spawn.hpp"
 #include "tmc/task.hpp"
 #include "tmc/traits.hpp"
@@ -45,43 +51,37 @@ template <class F> inline with_result_of_t<F> with_result_of(F&& f) {
   return with_result_of_t<F>(std::forward<F>(f));
 }
 
-// qu_unbounded_spsc is non-movable and non-copyable, so we share it via
+// qu_bounded_spsc is non-movable and non-copyable, so we share it via
 // shared_ptr to keep it alive for the lifetime of the single producer and
 // single consumer.
-template <typename T> using pipeline_queue = tmc::qu_unbounded_spsc<T>;
+struct pipeline_queue_config : tmc::qu_bounded_spsc_default_config {};
+template <typename T>
+using pipeline_queue = tmc::qu_bounded_spsc<T, pipeline_queue_config>;
 template <typename T>
 using pipeline_queue_ptr = std::shared_ptr<pipeline_queue<T>>;
 
-template <typename T> pipeline_queue_ptr<T> make_pipeline_queue() {
-  return std::make_shared<pipeline_queue<T>>();
+template <typename T> pipeline_queue_ptr<T> make_pipeline_queue(size_t size) {
+  return std::make_shared<pipeline_queue<T>>(size);
 }
 
-template <typename Input, typename Output, typename ProcessFunc, bool End>
+template <typename Input, typename Output, typename ProcessFunc>
 struct pipeline_stage {
   // The output queue contains forked task handles - this is how we manage
   // parallelism while ensuring FIFO ordering.
   using output_t = tmc::aw_spawn_fork<tmc::task<Output>>;
 
+  // This stage owns its own output queue. It is sized to `parallelism` so
+  // that at most `parallelism` forked task handles can be in flight: when
+  // the queue is full, `co_await outChan_->post()` suspends, preventing
+  // further forks until the downstream stage drains an entry.
   pipeline_queue_ptr<output_t> outChan_;
-  tmc::semaphore outSem_;
 
   template <typename CInput>
   static tmc::task<void> worker(
-    pipeline_queue_ptr<CInput> inChan, tmc::semaphore* inSem,
-    pipeline_queue_ptr<output_t> outChan, tmc::semaphore* outSem,
+    pipeline_queue_ptr<CInput> inChan, pipeline_queue_ptr<output_t> outChan,
     ProcessFunc func
   ) {
     while (auto input = co_await inChan->pull()) {
-      if (inSem != nullptr) {
-        inSem->release();
-      }
-
-      // Wait for the output semaphore so we can construct the data directly in
-      // the output queue
-      if (outSem != nullptr) {
-        co_await *outSem;
-      }
-
       if constexpr (tmc::traits::is_awaitable<CInput>) {
         auto data = co_await std::move(input.get());
         using FInput = tmc::traits::awaitable_result_t<CInput>;
@@ -89,12 +89,12 @@ struct pipeline_stage {
         if constexpr (tmc::traits::is_awaitable<
                         std::invoke_result_t<ProcessFunc, FInput&&>>) {
           // ProcessFunc is a coroutine
-          outChan->post(with_result_of([&]() {
+          co_await outChan->post(with_result_of([&]() {
             return tmc::spawn(func(std::move(data))).fork();
           }));
         } else {
           // ProcessFunc is a regular function
-          outChan->post(with_result_of([&]() {
+          co_await outChan->post(with_result_of([&]() {
             return tmc::spawn([](ProcessFunc f, FInput i) -> tmc::task<Output> {
                      co_return f(std::move(i));
                    }(func, std::move(data)))
@@ -107,12 +107,12 @@ struct pipeline_stage {
         if constexpr (tmc::traits::is_awaitable<
                         std::invoke_result_t<ProcessFunc, FInput&&>>) {
           // ProcessFunc is a coroutine
-          outChan->post(with_result_of([&]() {
+          co_await outChan->post(with_result_of([&]() {
             return tmc::spawn(func(std::move(input.get()))).fork();
           }));
         } else {
           // ProcessFunc is a regular function
-          outChan->post(with_result_of([&]() {
+          co_await outChan->post(with_result_of([&]() {
             return tmc::spawn([](ProcessFunc f, FInput i) -> tmc::task<Output> {
                      co_return f(std::move(i));
                    }(func, std::move(input.get())))
@@ -129,44 +129,53 @@ struct pipeline_stage {
 
   pipeline_stage(
     tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> inChan,
-    tmc::semaphore* inSem, ProcessFunc func, size_t parallelism
+    ProcessFunc func, size_t parallelism
   )
-      : outChan_(make_pipeline_queue<output_t>()),
-        // Initialize our output semaphore to 0. The next stage will set this
-        // semaphore capacity (for their input queue) based on their worker
-        // count.
-        outSem_(tmc::semaphore(0)) {
-
-    // Set our input queue capacity to 2x our worker count.
-    if (inSem != nullptr) {
-      inSem->release(2 * parallelism);
-    }
-
-    tmc::semaphore* outSem = &outSem_;
-    if constexpr (End) {
-      outSem = nullptr;
-    }
-
-    fg.fork(worker(inChan, inSem, outChan_, outSem, func));
+      : outChan_(make_pipeline_queue<output_t>(parallelism)) {
+    fg.fork(worker(inChan, outChan_, func));
   }
 
   pipeline_queue_ptr<output_t> get_channel() { return outChan_; }
 };
 
+// The start stage is a normal pipeline_stage that additionally owns its
+// input queue and exposes it as the public `in` member, so the driver has
+// somewhere to post the initial elements.
+template <typename Input, typename Output, typename ProcessFunc>
+struct pipeline_start_stage : pipeline_stage<Input, Output, ProcessFunc> {
+  pipeline_queue_ptr<Input> in;
+
+  pipeline_start_stage(
+    tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> inChan,
+    ProcessFunc func, size_t parallelism
+  )
+      : pipeline_stage<Input, Output, ProcessFunc>(
+          fg, inChan, func, parallelism
+        ),
+        in(std::move(inChan)) {}
+};
+
+// Creates the first stage of the pipeline. The driver writes input elements
+// to the returned stage's `in` member. The Input type must be specified
+// explicitly as a template argument.
 template <typename Input, typename Func>
 auto start_pipeline(
-  tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> from,
-  tmc::semaphore* inSem, Func transformFunc, size_t parallelism = 1
+  tmc::aw_fork_group<0, void>& fg, Func transformFunc, size_t parallelism = 1
 ) {
   using Intermediate = std::invoke_result_t<Func, Input&&>;
   using Output = std::conditional_t<
     tmc::traits::is_awaitable<Intermediate>,
     tmc::traits::awaitable_result_t<Intermediate>, Intermediate>;
-  return pipeline_stage<Input, Output, Func, false>{
-    fg, from, inSem, transformFunc, parallelism
+  // The input queue is sized to `parallelism` to give the driver buffering
+  // proportional to the stage's processing capacity.
+  auto inChan = make_pipeline_queue<Input>(parallelism);
+  return pipeline_start_stage<Input, Output, Func>{
+    fg, std::move(inChan), transformFunc, parallelism
   };
 }
 
+// Adds an intermediate stage that pulls from the prior stage's output queue
+// and forwards through its own output queue (sized to `parallelism`).
 template <typename PriorStage, typename Func>
 auto pipeline_transform(
   tmc::aw_fork_group<0, void>& fg, PriorStage& from, Func transformFunc,
@@ -180,19 +189,18 @@ auto pipeline_transform(
   using Output = std::conditional_t<
     tmc::traits::is_awaitable<IntermediateOutput>,
     tmc::traits::awaitable_result_t<IntermediateOutput>, IntermediateOutput>;
-  return pipeline_stage<Input, Output, Func, false>{
-    fg, from.outChan_, &from.outSem_, transformFunc, parallelism
+  return pipeline_stage<Input, Output, Func>{
+    fg, from.get_channel(), transformFunc, parallelism
   };
 }
 
 template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
+  // Fast path used when parallelism == 1: process each item inline in the
+  // consumer task, avoiding the internal queue and fork overhead entirely.
   template <typename CInput>
-  static tmc::task<void> worker(
-    pipeline_queue_ptr<CInput> inChan, tmc::semaphore* inSem, ProcessFunc func
-  ) {
+  static tmc::task<void>
+  inline_worker(pipeline_queue_ptr<CInput> inChan, ProcessFunc func) {
     while (auto input = co_await inChan->pull()) {
-      inSem->release();
-
       if constexpr (tmc::traits::is_awaitable<CInput>) {
         auto data = co_await std::move(input.get());
         using FInput = tmc::traits::awaitable_result_t<CInput>;
@@ -214,17 +222,91 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
     }
   }
 
+  template <typename CInput>
+  static tmc::task<void> worker(
+    pipeline_queue_ptr<CInput> inChan, ProcessFunc func, size_t parallelism
+  ) {
+    // Each in-flight consume runs as its own forked task. The internal
+    // bounded queue holds those fork handles so we can await them in FIFO
+    // order. Sized to `parallelism` - exactly large enough to hold all
+    // currently in-flight tasks.
+    using consume_fork_t = tmc::aw_spawn_fork<tmc::task<void>>;
+    auto internalQueue = make_pipeline_queue<consume_fork_t>(parallelism);
+
+    // Track the number of currently active (in-flight) consume tasks in
+    // a separate size_t. This lets us drain exactly when we hit the
+    // parallelism limit, so the next post() never blocks on a full queue.
+    size_t active = 0;
+
+    while (auto input = co_await inChan->pull()) {
+      if constexpr (tmc::traits::is_awaitable<CInput>) {
+        // Upstream queue contains forked task handles - await to get value.
+        auto data = co_await std::move(input.get());
+        using FInput = tmc::traits::awaitable_result_t<CInput>;
+        co_await internalQueue->post(with_result_of([&]() {
+          return tmc::spawn([](ProcessFunc f, FInput d) -> tmc::task<void> {
+                   if constexpr (tmc::traits::is_awaitable<
+                                   std::invoke_result_t<ProcessFunc, FInput&&>>) {
+                     co_await f(std::move(d));
+                   } else {
+                     f(std::move(d));
+                   }
+                   co_return;
+                 }(func, std::move(data)))
+            .fork();
+        }));
+      } else {
+        using FInput = CInput;
+        // Upstream queue contains values directly.
+        co_await internalQueue->post(with_result_of([&]() {
+          return tmc::spawn([](ProcessFunc f, FInput d) -> tmc::task<void> {
+                   if constexpr (tmc::traits::is_awaitable<
+                                   std::invoke_result_t<ProcessFunc, FInput&&>>) {
+                     co_await f(std::move(d));
+                   } else {
+                     f(std::move(d));
+                   }
+                   co_return;
+                 }(func, std::move(input.get())))
+            .fork();
+        }));
+      }
+      ++active;
+
+      // Hit the parallelism limit - drain one completion (in FIFO order)
+      // before the next iteration's post() could otherwise block.
+      if (active >= parallelism) {
+        auto handle = co_await internalQueue->pull();
+        co_await std::move(handle.get());
+        --active;
+      }
+    }
+
+    // Upstream is closed. Drain any remaining in-flight forks in order.
+    while (active > 0) {
+      auto handle = co_await internalQueue->pull();
+      co_await std::move(handle.get());
+      --active;
+    }
+  }
+
   pipeline_end_stage(
     tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> inChan,
-    tmc::semaphore* inSem, ProcessFunc func, size_t parallelism
+    ProcessFunc func, size_t parallelism
   ) {
-    // Set our input queue capacity to 2x our worker count.
-    inSem->release(2 * parallelism);
-
-    fg.fork(worker(inChan, inSem, func));
+    if (parallelism == 1) {
+      fg.fork(inline_worker(inChan, func));
+    } else {
+      fg.fork(worker(inChan, func, parallelism));
+    }
   }
 };
 
+// The terminal consumer of the pipeline. With `parallelism` > 1 it runs
+// up to that many consume() invocations concurrently. Completion of those
+// forked tasks is awaited in FIFO order, but the consume() bodies
+// themselves execute in parallel - if `consumeFunc` touches shared state,
+// the caller is responsible for synchronization.
 template <typename PriorStage, typename Func>
 auto end_pipeline(
   tmc::aw_fork_group<0, void>& fg, PriorStage& from, Func consumeFunc,
@@ -232,6 +314,6 @@ auto end_pipeline(
 ) {
   using Input = typename PriorStage::output_t;
   return pipeline_end_stage<Input, Func>{
-    fg, from.outChan_, &from.outSem_, consumeFunc, parallelism
+    fg, from.get_channel(), consumeFunc, parallelism
   };
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -136,6 +136,7 @@ make_exe_base(
   test_qu_lockfree.cpp
   test_qu_unbounded_mpsc.cpp
   test_qu_unbounded_spsc.cpp
+  test_qu_bounded_spsc.cpp
   test_thread_layout.cpp
   test_fork_group.cpp
   test_spawn_group.cpp

--- a/tests/test_qu_bounded_spsc.cpp
+++ b/tests/test_qu_bounded_spsc.cpp
@@ -24,8 +24,7 @@ static constexpr size_t SPSC_TEST_SENTINEL = static_cast<size_t>(-1);
 // largest bulk post in any single call (post_bulk requires Count <= capacity).
 static constexpr size_t TEST_CAPACITY = 128;
 
-template <size_t Pack>
-struct qu_config : tmc::qu_bounded_spsc_default_config {
+template <size_t Pack> struct qu_config : tmc::qu_bounded_spsc_default_config {
   static inline constexpr size_t PackingLevel = Pack;
   static inline constexpr bool ConsumerCanSuspend = true;
 };
@@ -122,9 +121,7 @@ void do_chan_test(Executor& Exec) {
             if (j > NITEMS) {
               j = NITEMS;
             }
-            co_await Chan.post_bulk(
-              std::ranges::views::iota(i).begin(), j - i
-            );
+            co_await Chan.post_bulk(std::ranges::views::iota(i).begin(), j - i);
           }
           co_return i;
         }(chan),
@@ -383,10 +380,12 @@ TEST_F(CATEGORY, try_pull_zc_scope_move_assign_over_nonempty) {
     std::atomic<size_t> count1{0};
     std::atomic<size_t> count2{0};
     {
-      auto q1 = tmc::qu_bounded_spsc<
-        spsc_destructor_counter, qu_config<0>>{TEST_CAPACITY};
-      auto q2 = tmc::qu_bounded_spsc<
-        spsc_destructor_counter, qu_config<0>>{TEST_CAPACITY};
+      auto q1 = tmc::qu_bounded_spsc<spsc_destructor_counter, qu_config<0>>{
+        TEST_CAPACITY
+      };
+      auto q2 = tmc::qu_bounded_spsc<spsc_destructor_counter, qu_config<0>>{
+        TEST_CAPACITY
+      };
       co_await q1.post(spsc_destructor_counter{&count1});
       co_await q2.post(spsc_destructor_counter{&count2});
 
@@ -547,6 +546,38 @@ TEST_F(CATEGORY, close_resume_inline_wakes_suspended_consumer) {
     EXPECT_FALSE(
       got_value
     ); // consumer was woken by close_resume_inline with empty scope
+    co_return;
+  }());
+}
+
+TEST_F(CATEGORY, pull_after_closed) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    using qerr = tmc::qu_bounded_spsc_err;
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+
+    auto results = co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<void> {
+        // Suspend on the empty cutoff slot.
+        auto v = co_await Chan.pull();
+        EXPECT_FALSE(static_cast<bool>(v)); // woken by close, empty.
+
+        // Now poll the same slot. Per the close() contract this must
+        // immediately return CLOSED again.
+        auto v2 = Chan.try_pull();
+        EXPECT_EQ(qerr::CLOSED, v2.status());
+        EXPECT_EQ(false, v2.has_value());
+        auto v3 = co_await Chan.pull();
+        EXPECT_EQ(false, v3.has_value());
+      }(chan),
+      [](auto& Chan) -> tmc::task<void> {
+        // Yield to give the consumer a chance to suspend.
+        for (size_t i = 0; i < 10; ++i) {
+          co_await tmc::reschedule();
+        }
+        Chan.close();
+      }(chan)
+    );
+
     co_return;
   }());
 }

--- a/tests/test_qu_bounded_spsc.cpp
+++ b/tests/test_qu_bounded_spsc.cpp
@@ -632,6 +632,167 @@ TEST_F(CATEGORY, post_bulk_range) {
   }());
 }
 
+// post() wakes a consumer suspended on the slot it writes. Exercises the
+// branch in aw_post_impl::await_resume that captures the waiting consumer
+// pointer returned by write_element and posts its resumption.
+TEST_F(CATEGORY, post_wakes_suspended_consumer) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+
+    auto results = co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<size_t> {
+        size_t sum = 0;
+        while (auto v = co_await Chan.pull()) {
+          sum += *v;
+        }
+        co_return sum;
+      }(chan),
+      [](auto& Chan) -> tmc::task<void> {
+        // Yield to give the consumer a chance to suspend.
+        for (size_t i = 0; i < 10; ++i) {
+          co_await tmc::reschedule();
+        }
+        co_await Chan.post(123u);
+        co_await Chan.post(456u);
+        Chan.close();
+        co_return;
+      }(chan)
+    );
+
+    EXPECT_EQ(123u + 456u, std::get<0>(results));
+    co_return;
+  }());
+}
+
+// Fill the queue to capacity, then have the producer attempt one more post()
+// which must suspend until the consumer drains. Exercises
+// aw_post_impl::await_suspend (producer suspension on a DATA_BIT slot) and
+// finish_read's branch that wakes a producer when prev flags is a
+// producer_base*.
+TEST_F(CATEGORY, post_suspends_when_full) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    // Tiny capacity so we can easily fill the queue.
+    static constexpr size_t CAP = 4;
+    static constexpr size_t NITEMS = 32;
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{CAP};
+
+    auto results = co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<size_t> {
+        size_t sum = 0;
+        for (size_t i = 0; i < NITEMS; ++i) {
+          // Each post may suspend once the queue fills up.
+          co_await Chan.post(i);
+          sum += i;
+        }
+        co_return sum;
+      }(chan),
+      [](auto& Chan) -> tmc::task<size_t> {
+        // Give the producer time to fill the queue and suspend.
+        for (size_t i = 0; i < 20; ++i) {
+          co_await tmc::reschedule();
+        }
+        size_t sum = 0;
+        for (size_t i = 0; i < NITEMS; ++i) {
+          auto v = co_await Chan.pull();
+          EXPECT_TRUE(static_cast<bool>(v));
+          sum += *v;
+        }
+        co_return sum;
+      }(chan)
+    );
+
+    size_t expected = 0;
+    for (size_t i = 0; i < NITEMS; ++i) {
+      expected += i;
+    }
+    EXPECT_EQ(expected, std::get<0>(results));
+    EXPECT_EQ(expected, std::get<1>(results));
+    co_return;
+  }());
+}
+
+// Fill the queue to capacity, then have the producer attempt a post_bulk()
+// that does not fit. Exercises aw_post_bulk_impl::await_suspend (producer
+// suspension on a full bulk slot) and the finish_read wake-producer branch.
+TEST_F(CATEGORY, post_bulk_suspends_when_full) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    static constexpr size_t CAP = 4;
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{CAP};
+
+    auto results = co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<size_t> {
+        size_t items[CAP] = {1, 2, 3, 4};
+        // First fill the queue exactly.
+        co_await Chan.post_bulk(&items[0], CAP);
+        // This second post_bulk cannot fit any element; producer must
+        // suspend until the consumer drains the queue.
+        size_t more[CAP] = {10, 20, 30, 40};
+        co_await Chan.post_bulk(&more[0], CAP);
+        co_return 1u + 2u + 3u + 4u + 10u + 20u + 30u + 40u;
+      }(chan),
+      [](auto& Chan) -> tmc::task<size_t> {
+        // Give the producer time to fill and then suspend on post_bulk.
+        for (size_t i = 0; i < 20; ++i) {
+          co_await tmc::reschedule();
+        }
+        size_t sum = 0;
+        for (size_t i = 0; i < 2 * CAP; ++i) {
+          auto v = co_await Chan.pull();
+          EXPECT_TRUE(static_cast<bool>(v));
+          sum += *v;
+        }
+        co_return sum;
+      }(chan)
+    );
+
+    EXPECT_EQ(std::get<0>(results), std::get<1>(results));
+    co_return;
+  }());
+}
+
+// empty() returns true on an empty queue and false after a post; returns true
+// again after a try_pull drains the slot. Exercises empty() and the
+// is_data_waiting() helper.
+TEST_F(CATEGORY, empty_method) {
+  tmc::ex_cpu ex;
+  ex.set_thread_count(1).init();
+  test_async_main(ex, []() -> tmc::task<void> {
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    EXPECT_TRUE(chan.empty());
+
+    co_await chan.post(7u);
+    EXPECT_FALSE(chan.empty());
+
+    {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      EXPECT_EQ(7u, *v);
+    }
+    EXPECT_TRUE(chan.empty());
+
+    // Bulk fill, then drain.
+    size_t items[3] = {100, 200, 300};
+    co_await chan.post_bulk(&items[0], 3);
+    EXPECT_FALSE(chan.empty());
+    {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+    }
+    EXPECT_FALSE(chan.empty());
+    {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+    }
+    EXPECT_FALSE(chan.empty());
+    {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+    }
+    EXPECT_TRUE(chan.empty());
+    co_return;
+  }());
+}
+
 // post_bulk(Range) with an empty range must be a no-op.
 TEST_F(CATEGORY, post_bulk_range_empty) {
   tmc::ex_cpu ex;

--- a/tests/test_qu_bounded_spsc.cpp
+++ b/tests/test_qu_bounded_spsc.cpp
@@ -555,7 +555,7 @@ TEST_F(CATEGORY, pull_after_closed) {
     using qerr = tmc::qu_bounded_spsc_err;
     auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
 
-    auto results = co_await tmc::spawn_tuple(
+    co_await tmc::spawn_tuple(
       [](auto& Chan) -> tmc::task<void> {
         // Suspend on the empty cutoff slot.
         auto v = co_await Chan.pull();

--- a/tests/test_qu_bounded_spsc.cpp
+++ b/tests/test_qu_bounded_spsc.cpp
@@ -1,0 +1,658 @@
+#include "test_common.hpp"
+#include "tmc/detail/compat.hpp"
+#include "tmc/qu_bounded_spsc.hpp"
+
+#include <cstddef>
+#include <gtest/gtest.h>
+#include <ranges>
+#include <vector>
+
+#define CATEGORY test_qu_bounded_spsc
+
+class CATEGORY : public testing::Test {
+protected:
+  static void SetUpTestSuite() { tmc::cpu_executor().init(); }
+
+  static void TearDownTestSuite() { tmc::cpu_executor().teardown(); }
+
+  static tmc::ex_cpu& ex() { return tmc::cpu_executor(); }
+};
+
+static constexpr size_t SPSC_TEST_SENTINEL = static_cast<size_t>(-1);
+
+// Default capacity used by tests below. Must be large enough to hold the
+// largest bulk post in any single call (post_bulk requires Count <= capacity).
+static constexpr size_t TEST_CAPACITY = 128;
+
+template <size_t Pack>
+struct qu_config : tmc::qu_bounded_spsc_default_config {
+  static inline constexpr size_t PackingLevel = Pack;
+  static inline constexpr bool ConsumerCanSuspend = true;
+};
+
+// This version has to be default constructible
+struct spsc_destructor_counter {
+  std::atomic<size_t>* count;
+  spsc_destructor_counter() noexcept : count{nullptr} {}
+  spsc_destructor_counter(std::atomic<size_t>* C) noexcept : count{C} {}
+  spsc_destructor_counter(spsc_destructor_counter const& Other) = delete;
+  spsc_destructor_counter&
+  operator=(spsc_destructor_counter const& Other) = delete;
+
+  spsc_destructor_counter(spsc_destructor_counter&& Other) noexcept {
+    count = Other.count;
+    Other.count = nullptr;
+  }
+  spsc_destructor_counter& operator=(spsc_destructor_counter&& Other) noexcept {
+    count = Other.count;
+    Other.count = nullptr;
+    return *this;
+  }
+
+  ~spsc_destructor_counter() {
+    if (count != nullptr) {
+      ++(*count);
+    }
+  }
+};
+
+// multiple tests in one to leverage the configuration options in one place
+template <size_t PackingLevel, typename Executor>
+void do_chan_test(Executor& Exec) {
+  test_async_main(Exec, []() -> tmc::task<void> {
+    {
+      // general test - single push
+      static constexpr size_t NITEMS = 1000;
+      struct result {
+        size_t count;
+        size_t sum;
+      };
+
+      auto chan =
+        tmc::qu_bounded_spsc<size_t, qu_config<PackingLevel>>{TEST_CAPACITY};
+
+      auto results = co_await tmc::spawn_tuple(
+        [](auto& Chan) -> tmc::task<size_t> {
+          size_t i = 0;
+          for (; i < NITEMS; ++i) {
+            co_await Chan.post(i);
+          }
+          co_await Chan.post(SPSC_TEST_SENTINEL);
+          co_return i;
+        }(chan),
+        [](auto& Chan) -> tmc::task<result> {
+          size_t count = 0;
+          size_t sum = 0;
+          while (true) {
+            auto v = co_await Chan.pull();
+            if (*v == SPSC_TEST_SENTINEL) {
+              co_return result{count, sum};
+            }
+            ++count;
+            sum += *v;
+          }
+        }(chan)
+      );
+      auto& prod = std::get<0>(results);
+      auto& cons = std::get<1>(results);
+      EXPECT_EQ(NITEMS, prod);
+      EXPECT_EQ(NITEMS, cons.count);
+      size_t expectedSum = 0;
+      for (size_t i = 0; i < NITEMS; ++i) {
+        expectedSum += i;
+      }
+      EXPECT_EQ(expectedSum, cons.sum);
+    }
+    {
+      // general test - post_bulk
+      static constexpr size_t NITEMS = 1000;
+      struct result {
+        size_t count;
+        size_t sum;
+      };
+
+      auto chan =
+        tmc::qu_bounded_spsc<size_t, qu_config<PackingLevel>>{TEST_CAPACITY};
+
+      auto results = co_await tmc::spawn_tuple(
+        [](auto& Chan) -> tmc::task<size_t> {
+          size_t i = 0;
+          for (; i < NITEMS; i += (NITEMS / 10)) {
+            size_t j = i + (NITEMS / 10);
+            if (j > NITEMS) {
+              j = NITEMS;
+            }
+            co_await Chan.post_bulk(
+              std::ranges::views::iota(i).begin(), j - i
+            );
+          }
+          co_return i;
+        }(chan),
+        [](auto& Chan) -> tmc::task<result> {
+          size_t count = 0;
+          size_t sum = 0;
+          for (size_t i = 0; i < NITEMS; ++i) {
+            auto v = Chan.try_pull();
+            while (!v) {
+              TMC_CPU_PAUSE();
+              v = Chan.try_pull();
+            }
+            ++count;
+            sum += *v;
+          }
+          co_return result{count, sum};
+        }(chan)
+      );
+      auto& prod = std::get<0>(results);
+      auto& cons = std::get<1>(results);
+      EXPECT_EQ(NITEMS, prod);
+      EXPECT_EQ(NITEMS, cons.count);
+      size_t expectedSum = 0;
+      for (size_t i = 0; i < NITEMS; ++i) {
+        expectedSum += i;
+      }
+      EXPECT_EQ(expectedSum, cons.sum);
+    }
+    {
+      // destroy chan with data remaining inside
+      std::atomic<size_t> count;
+      {
+        auto chan = tmc::qu_bounded_spsc<
+          spsc_destructor_counter, qu_config<PackingLevel>>{TEST_CAPACITY};
+        for (size_t i = 0; i < 12; ++i) {
+          co_await chan.post(spsc_destructor_counter{&count});
+        }
+
+        for (size_t i = 0; i < 7; ++i) {
+          auto v = chan.try_pull();
+          EXPECT_TRUE(static_cast<bool>(v));
+        }
+
+        EXPECT_EQ(count.load(), 7);
+      }
+      // Now chan goes out of scope; remaining data's destructors are called
+      EXPECT_EQ(count.load(), 12);
+    }
+  }());
+}
+
+TEST_F(CATEGORY, config_sweep) {
+  do_chan_test<0>(ex());
+  do_chan_test<1>(ex());
+}
+
+// Test post_bulk of 0 items
+TEST_F(CATEGORY, post_bulk_none) {
+  tmc::ex_cpu ex;
+  ex.set_thread_count(1).init();
+  test_async_main(ex, []() -> tmc::task<void> {
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    size_t i = 0;
+    for (; i < 4; ++i) {
+      co_await chan.post_bulk(&i, 0);
+      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
+      co_await chan.post(i);
+    }
+    for (; i < 8; ++i) {
+      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
+      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
+      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 1);
+    }
+    size_t count = 0;
+    size_t sum = 0;
+    for (size_t j = 0; j < i; ++j) {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      sum += *v;
+      ++count;
+    }
+    EXPECT_EQ(28, sum);
+    EXPECT_EQ(8, count);
+
+    auto v = chan.try_pull();
+    EXPECT_FALSE(static_cast<bool>(v));
+    co_return;
+  }());
+}
+
+struct chan_config_no_suspend : tmc::qu_bounded_spsc_default_config {
+  static inline constexpr bool ConsumerCanSuspend = false;
+};
+
+// Verify that try_pull works when ConsumerCanSuspend = false (pull() is
+// disabled in this configuration).
+TEST_F(CATEGORY, try_pull_no_suspend) {
+  tmc::ex_cpu ex;
+  ex.set_thread_count(1).init();
+  test_async_main(ex, []() -> tmc::task<void> {
+    auto chan =
+      tmc::qu_bounded_spsc<size_t, chan_config_no_suspend>{TEST_CAPACITY};
+
+    // Empty queue: try_pull yields an empty scope.
+    {
+      auto v = chan.try_pull();
+      EXPECT_FALSE(static_cast<bool>(v));
+    }
+
+    // Post enough items to exercise the queue.
+    static constexpr size_t NITEMS = 10;
+    for (size_t i = 0; i < NITEMS; ++i) {
+      co_await chan.post(i);
+    }
+
+    size_t sum = 0;
+    size_t count = 0;
+    for (size_t i = 0; i < NITEMS; ++i) {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      sum += *v;
+      ++count;
+    }
+    EXPECT_EQ(NITEMS, count);
+    size_t expectedSum = 0;
+    for (size_t i = 0; i < NITEMS; ++i) {
+      expectedSum += i;
+    }
+    EXPECT_EQ(expectedSum, sum);
+
+    // Queue is drained: try_pull again yields an empty scope.
+    {
+      auto v = chan.try_pull();
+      EXPECT_FALSE(static_cast<bool>(v));
+    }
+    co_return;
+  }());
+}
+
+// A type with no default, copy, or move constructor. Can only be created
+// in-place via post()'s emplace forwarding.
+struct non_movable {
+  int value;
+
+  non_movable(int X, int Y) noexcept : value{X + Y} {}
+
+  non_movable() = delete;
+  non_movable(non_movable const&) = delete;
+  non_movable(non_movable&&) = delete;
+  non_movable& operator=(non_movable const&) = delete;
+  non_movable& operator=(non_movable&&) = delete;
+};
+
+TEST_F(CATEGORY, non_movable_type) {
+  tmc::ex_cpu ex;
+  ex.set_thread_count(1).init();
+  test_async_main(ex, []() -> tmc::task<void> {
+    auto chan = tmc::qu_bounded_spsc<non_movable, qu_config<0>>{TEST_CAPACITY};
+
+    // try_pull on empty queue
+    {
+      auto v = chan.try_pull();
+      EXPECT_FALSE(static_cast<bool>(v));
+    }
+
+    // Emplace-construct values directly in the queue storage.
+    co_await chan.post(1, 2);
+    co_await chan.post(3, 4);
+    co_await chan.post(5, 6);
+
+    // First value via try_pull
+    {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      EXPECT_EQ(3, v->value);
+    }
+
+    // Second value via co_await pull()
+    {
+      auto v = co_await chan.pull();
+      EXPECT_EQ(7, v->value);
+    }
+
+    // Third value via try_pull
+    {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      EXPECT_EQ(11, v->value);
+    }
+
+    // Queue is drained
+    {
+      auto v = chan.try_pull();
+      EXPECT_FALSE(static_cast<bool>(v));
+    }
+
+    co_return;
+  }());
+}
+
+// try_pull on a closed, empty queue returns CLOSED status.
+TEST_F(CATEGORY, try_pull_closed_empty) {
+  tmc::ex_cpu ex;
+  ex.set_thread_count(1).init();
+  test_async_main(ex, []() -> tmc::task<void> {
+    using qerr = tmc::qu_bounded_spsc_err;
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    chan.close();
+
+    auto v = chan.try_pull();
+    EXPECT_EQ(qerr::CLOSED, v.status());
+    EXPECT_FALSE(static_cast<bool>(v));
+    co_return;
+  }());
+}
+
+// close() is idempotent: a second call must be a no-op.
+TEST_F(CATEGORY, close_idempotent) {
+  tmc::ex_cpu ex;
+  ex.set_thread_count(1).init();
+  test_async_main(ex, []() -> tmc::task<void> {
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    chan.close();
+    chan.close();
+    chan.close();
+    co_return;
+  }());
+}
+
+// pull() after close() returns an empty scope. This exercises the
+// aw_pull::await_suspend branch where try_wait observes CLOSED_BIT.
+TEST_F(CATEGORY, pull_after_close_returns_empty) {
+  tmc::ex_cpu ex;
+  ex.set_thread_count(1).init();
+  test_async_main(ex, []() -> tmc::task<void> {
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    chan.close();
+
+    auto v = co_await chan.pull();
+    EXPECT_FALSE(static_cast<bool>(v));
+
+    // A second pull() should also yield an empty scope.
+    auto v2 = co_await chan.pull();
+    EXPECT_FALSE(static_cast<bool>(v2));
+    co_return;
+  }());
+}
+
+// Move-assignment of try_pull_zc_scope when the destination already holds a
+// value. Two distinct queues are used because the API requires that at most
+// one scope from a given queue be live at a time. The destination scope's
+// element must be released (destroyed + slot freed) before adopting the
+// source's element.
+TEST_F(CATEGORY, try_pull_zc_scope_move_assign_over_nonempty) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    std::atomic<size_t> count1{0};
+    std::atomic<size_t> count2{0};
+    {
+      auto q1 = tmc::qu_bounded_spsc<
+        spsc_destructor_counter, qu_config<0>>{TEST_CAPACITY};
+      auto q2 = tmc::qu_bounded_spsc<
+        spsc_destructor_counter, qu_config<0>>{TEST_CAPACITY};
+      co_await q1.post(spsc_destructor_counter{&count1});
+      co_await q2.post(spsc_destructor_counter{&count2});
+
+      auto v1 = q1.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v1));
+      auto v2 = q2.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v2));
+      EXPECT_EQ(0u, count1.load());
+      EXPECT_EQ(0u, count2.load());
+
+      // Move-assign over a non-empty scope. v1's existing element (from q1)
+      // must be destroyed and its slot released; v1 then takes ownership of
+      // v2's element (from q2).
+      v1 = std::move(v2);
+      EXPECT_FALSE(static_cast<bool>(v2));
+      EXPECT_TRUE(static_cast<bool>(v1));
+      EXPECT_EQ(1u, count1.load()); // q1's slot was destroyed by the assign
+      EXPECT_EQ(0u, count2.load()); // q2's element now lives in v1
+    } // ~v1 destroys q2's element (count2 -> 1); both queues then destruct.
+    EXPECT_EQ(1u, count1.load());
+    EXPECT_EQ(1u, count2.load());
+    co_return;
+  }());
+}
+
+// close() wakes a consumer suspended on an empty slot. The consumer is parked
+// at slot 0 (no producer has posted), then close() races in and publishes the
+// CLOSED sentinel at slot 0, returning the waiting consumer pointer which
+// close() then resumes.
+TEST_F(CATEGORY, close_wakes_suspended_consumer) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+
+    auto results = co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<bool> {
+        auto v = co_await Chan.pull();
+        co_return static_cast<bool>(v);
+      }(chan),
+      [](auto& Chan) -> tmc::task<void> {
+        // Yield to give the consumer a chance to suspend.
+        for (size_t i = 0; i < 10; ++i) {
+          co_await tmc::reschedule();
+        }
+        Chan.close();
+        co_return;
+      }(chan)
+    );
+
+    bool got_value = std::get<0>(results);
+    EXPECT_FALSE(got_value); // consumer was woken by close with empty scope
+    co_return;
+  }());
+}
+
+// post_bulk() wakes a consumer suspended on the slot it writes. Exercises
+// the branch in post_bulk that captures the waiting consumer pointer
+// returned by write_element and posts its resumption.
+TEST_F(CATEGORY, post_bulk_wakes_suspended_consumer) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+
+    auto results = co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<size_t> {
+        // Consumer suspends at slot 0; post_bulk wakes it. Drain everything
+        // until the queue is closed (empty scope). Each pull_zc_scope must
+        // be released before the next pull() runs, since the queue requires
+        // that at most one scope from a given queue be live at a time.
+        size_t sum = 0;
+        while (auto v = co_await Chan.pull()) {
+          sum += *v;
+        }
+        co_return sum;
+      }(chan),
+      [](auto& Chan) -> tmc::task<void> {
+        // Yield to give the consumer a chance to suspend.
+        for (size_t i = 0; i < 10; ++i) {
+          co_await tmc::reschedule();
+        }
+        size_t items[5] = {10, 20, 30, 40, 50};
+        co_await Chan.post_bulk(&items[0], 5);
+        Chan.close();
+        co_return;
+      }(chan)
+    );
+
+    EXPECT_EQ(10u + 20u + 30u + 40u + 50u, std::get<0>(results));
+    co_return;
+  }());
+}
+
+// close_resume_inline() with no waiting consumer: behaves like close() in
+// that subsequent posts must not be used, and pre-close posts can still drain.
+TEST_F(CATEGORY, close_resume_inline_no_waiting_consumer) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    using qerr = tmc::qu_bounded_spsc_err;
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+
+    for (size_t i = 0; i < 5; ++i) {
+      co_await chan.post(i);
+    }
+
+    chan.close_resume_inline();
+
+    // Drain the queue.
+    size_t sum = 0;
+    size_t count = 0;
+    while (true) {
+      auto v = chan.try_pull();
+      if (v.status() == qerr::OK) {
+        sum += *v;
+        ++count;
+      } else if (v.status() == qerr::CLOSED) {
+        break;
+      } else {
+        ADD_FAILURE() << "Unexpected EMPTY after close_resume_inline";
+        break;
+      }
+    }
+    EXPECT_EQ(5u, count);
+    EXPECT_EQ(0u + 1u + 2u + 3u + 4u, sum);
+
+    // Further try_pull stays CLOSED.
+    auto v = chan.try_pull();
+    EXPECT_EQ(qerr::CLOSED, v.status());
+    EXPECT_FALSE(static_cast<bool>(v));
+
+    // close_resume_inline() is idempotent.
+    chan.close_resume_inline();
+    chan.close();
+    co_return;
+  }());
+}
+
+// close_resume_inline() wakes a consumer suspended on an empty slot, just like
+// close() does. The consumer is parked at slot 0 (no producer has posted),
+// then close_resume_inline() races in and publishes the CLOSED sentinel at slot
+// 0, which wakes the consumer (resumed inline) with an empty scope.
+TEST_F(CATEGORY, close_resume_inline_wakes_suspended_consumer) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+
+    auto results = co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<bool> {
+        auto v = co_await Chan.pull();
+        co_return static_cast<bool>(v);
+      }(chan),
+      [](auto& Chan) -> tmc::task<void> {
+        // Yield to give the consumer a chance to suspend.
+        for (size_t i = 0; i < 10; ++i) {
+          co_await tmc::reschedule();
+        }
+        Chan.close_resume_inline();
+        co_return;
+      }(chan)
+    );
+
+    bool got_value = std::get<0>(results);
+    EXPECT_FALSE(
+      got_value
+    ); // consumer was woken by close_resume_inline with empty scope
+    co_return;
+  }());
+}
+
+// post_bulk(Begin, End) iterator-pair overload: pushes [Begin, End) into the
+// queue and drains them in order.
+TEST_F(CATEGORY, post_bulk_iterator_pair) {
+  tmc::ex_cpu ex;
+  ex.set_thread_count(1).init();
+  test_async_main(ex, []() -> tmc::task<void> {
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+
+    std::vector<size_t> items{1, 2, 3, 4, 5, 6, 7};
+    co_await chan.post_bulk(items.begin(), items.end());
+
+    size_t sum = 0;
+    size_t count = 0;
+    for (size_t i = 0; i < items.size(); ++i) {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      sum += *v;
+      ++count;
+    }
+    EXPECT_EQ(items.size(), count);
+    EXPECT_EQ(1u + 2u + 3u + 4u + 5u + 6u + 7u, sum);
+
+    // Queue is drained.
+    auto empty = chan.try_pull();
+    EXPECT_FALSE(static_cast<bool>(empty));
+    co_return;
+  }());
+}
+
+// post_bulk(Begin, End) with Begin == End must be a no-op.
+TEST_F(CATEGORY, post_bulk_iterator_pair_empty) {
+  tmc::ex_cpu ex;
+  ex.set_thread_count(1).init();
+  test_async_main(ex, []() -> tmc::task<void> {
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+
+    std::vector<size_t> empty_items;
+    co_await chan.post_bulk(empty_items.begin(), empty_items.end());
+
+    // Queue should still be empty.
+    auto v = chan.try_pull();
+    EXPECT_FALSE(static_cast<bool>(v));
+
+    // A real post afterwards should still work and arrive at slot 0.
+    co_await chan.post(42u);
+    auto v2 = chan.try_pull();
+    EXPECT_TRUE(static_cast<bool>(v2));
+    EXPECT_EQ(42u, *v2);
+    co_return;
+  }());
+}
+
+// post_bulk(Range) overload: pushes the range into the queue and drains in
+// order.
+TEST_F(CATEGORY, post_bulk_range) {
+  tmc::ex_cpu ex;
+  ex.set_thread_count(1).init();
+  test_async_main(ex, []() -> tmc::task<void> {
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+
+    std::vector<size_t> items{10, 20, 30, 40, 50};
+    co_await chan.post_bulk(items);
+
+    size_t sum = 0;
+    size_t count = 0;
+    for (size_t i = 0; i < items.size(); ++i) {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      sum += *v;
+      ++count;
+    }
+    EXPECT_EQ(items.size(), count);
+    EXPECT_EQ(10u + 20u + 30u + 40u + 50u, sum);
+
+    // Queue is drained.
+    auto empty = chan.try_pull();
+    EXPECT_FALSE(static_cast<bool>(empty));
+    co_return;
+  }());
+}
+
+// post_bulk(Range) with an empty range must be a no-op.
+TEST_F(CATEGORY, post_bulk_range_empty) {
+  tmc::ex_cpu ex;
+  ex.set_thread_count(1).init();
+  test_async_main(ex, []() -> tmc::task<void> {
+    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+
+    std::vector<size_t> empty_items;
+    co_await chan.post_bulk(empty_items);
+
+    // Queue should still be empty.
+    auto v = chan.try_pull();
+    EXPECT_FALSE(static_cast<bool>(v));
+
+    // A real post afterwards should still work and arrive at slot 0.
+    co_await chan.post(99u);
+    auto v2 = chan.try_pull();
+    EXPECT_TRUE(static_cast<bool>(v2));
+    EXPECT_EQ(99u, *v2);
+    co_return;
+  }());
+}
+
+#undef CATEGORY


### PR DESCRIPTION
Tests for https://github.com/tzcnt/TooManyCooks/pull/231

Reverted `pipeline.cpp` to the prior version and it depends on `pipeline.hpp` only now.

Added a new `pipeline_fifo.cpp` and updated `pipeline_fifo.hpp` to use `tmc::qu_bounded_spsc`. Replaced the semaphores with bounded queues to limit concurrency.