### PR TITLE
rename queues to put consumer/producer arity first

### DIFF
--- a/examples/pipeline_fifo.cpp
+++ b/examples/pipeline_fifo.cpp
@@ -51,7 +51,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]) {
     // Each stage owns its own output queue, sized to that stage's parallelism
     // parameter. The bounded output queue provides backpressure and gates the
     // stage's own in-flight parallelism. The start stage additionally owns
-    // its input queue (the queue the driver posts to), exposed as `.in`.
+    // its input queue (the queue the driver pushes to), exposed as `.in`.
     auto first = start_pipeline<int>(fg, plus_half, 10);
     auto second = pipeline_transform(fg, first, times_two, 10);
     auto third = pipeline_transform(fg, second, minus_one, 10);
@@ -63,7 +63,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]) {
     // This final stage has been configured to serialize the results by setting
     // parallelism = 1. Results will appear in the same order as the original
     // input. Another option would be to consume the results directly from the
-    // prior stage's get_channel().
+    // prior stage's get_queue().
     [[maybe_unused]] auto fifth = end_pipeline(
       fg, fourth,
       [&sum, &count](bool i) {
@@ -79,14 +79,14 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]) {
       // Run the initial producer task inline. Optionally, this could also be
       // added to the fg.
       for (int i = 0; i < NELEMS; ++i) {
-        // The bounded queue's post() suspends when the queue is full,
+        // The bounded queue's push() suspends when the queue is full,
         // providing backpressure to the producer.
-        co_await first.in->post(i);
+        co_await first.input_queue->push(i);
       }
       // Close the input queue. The first stage worker will drain remaining
       // items and then close its output queue, propagating closure through
       // the pipeline. Awaiting the fork_group below ensures full drain.
-      first.in->close();
+      first.input_queue->close();
     }
 
     co_await std::move(fg);

--- a/examples/pipeline_fifo.hpp
+++ b/examples/pipeline_fifo.hpp
@@ -26,7 +26,7 @@
 // addition to its output queue, and exposes it as the public `in` member.
 
 #include "tmc/fork_group.hpp"
-#include "tmc/qu_bounded_spsc.hpp"
+#include "tmc/qu_spsc_bounded.hpp"
 #include "tmc/spawn.hpp"
 #include "tmc/task.hpp"
 #include "tmc/traits.hpp"
@@ -51,12 +51,12 @@ template <class F> inline with_result_of_t<F> with_result_of(F&& f) {
   return with_result_of_t<F>(std::forward<F>(f));
 }
 
-// qu_bounded_spsc is non-movable and non-copyable, so we share it via
+// qu_spsc_bounded is non-movable and non-copyable, so we share it via
 // shared_ptr to keep it alive for the lifetime of the single producer and
 // single consumer.
-struct pipeline_queue_config : tmc::qu_bounded_spsc_default_config {};
+struct pipeline_queue_config : tmc::qu_spsc_bounded_default_config {};
 template <typename T>
-using pipeline_queue = tmc::qu_bounded_spsc<T, pipeline_queue_config>;
+using pipeline_queue = tmc::qu_spsc_bounded<T, pipeline_queue_config>;
 template <typename T>
 using pipeline_queue_ptr = std::shared_ptr<pipeline_queue<T>>;
 
@@ -245,8 +245,8 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
         using FInput = tmc::traits::awaitable_result_t<CInput>;
         co_await internalQueue->post(with_result_of([&]() {
           return tmc::spawn([](ProcessFunc f, FInput d) -> tmc::task<void> {
-                   if constexpr (tmc::traits::is_awaitable<
-                                   std::invoke_result_t<ProcessFunc, FInput&&>>) {
+                   if constexpr (tmc::traits::is_awaitable<std::invoke_result_t<
+                                   ProcessFunc, FInput&&>>) {
                      co_await f(std::move(d));
                    } else {
                      f(std::move(d));
@@ -260,8 +260,8 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
         // Upstream queue contains values directly.
         co_await internalQueue->post(with_result_of([&]() {
           return tmc::spawn([](ProcessFunc f, FInput d) -> tmc::task<void> {
-                   if constexpr (tmc::traits::is_awaitable<
-                                   std::invoke_result_t<ProcessFunc, FInput&&>>) {
+                   if constexpr (tmc::traits::is_awaitable<std::invoke_result_t<
+                                   ProcessFunc, FInput&&>>) {
                      co_await f(std::move(d));
                    } else {
                      f(std::move(d));

--- a/examples/pipeline_fifo.hpp
+++ b/examples/pipeline_fifo.hpp
@@ -20,9 +20,9 @@
 
 // Each stage owns its own output queue, sized to that stage's parallelism
 // parameter. The bounded output queue gates the stage's own in-flight
-// parallelism: when the queue is full, the stage's worker blocks on post(),
+// parallelism: when the queue is full, the stage's worker blocks on push(),
 // preventing it from forking more work than `parallelism` items at a time.
-// The start stage owns its input queue (the queue the driver posts to) in
+// The start stage owns its input queue (the queue the driver pushs to) in
 // addition to its output queue, and exposes it as the public `in` member.
 
 #include "tmc/fork_group.hpp"
@@ -72,16 +72,16 @@ struct pipeline_stage {
 
   // This stage owns its own output queue. It is sized to `parallelism` so
   // that at most `parallelism` forked task handles can be in flight: when
-  // the queue is full, `co_await outChan_->post()` suspends, preventing
+  // the queue is full, `co_await outQueue->push()` suspends, preventing
   // further forks until the downstream stage drains an entry.
-  pipeline_queue_ptr<output_t> outChan_;
+  pipeline_queue_ptr<output_t> output_queue;
 
   template <typename CInput>
   static tmc::task<void> worker(
-    pipeline_queue_ptr<CInput> inChan, pipeline_queue_ptr<output_t> outChan,
+    pipeline_queue_ptr<CInput> inQueue, pipeline_queue_ptr<output_t> outQueue,
     ProcessFunc func
   ) {
-    while (auto input = co_await inChan->pull()) {
+    while (auto input = co_await inQueue->pull()) {
       if constexpr (tmc::traits::is_awaitable<CInput>) {
         auto data = co_await std::move(input.get());
         using FInput = tmc::traits::awaitable_result_t<CInput>;
@@ -89,12 +89,12 @@ struct pipeline_stage {
         if constexpr (tmc::traits::is_awaitable<
                         std::invoke_result_t<ProcessFunc, FInput&&>>) {
           // ProcessFunc is a coroutine
-          co_await outChan->post(with_result_of([&]() {
+          co_await outQueue->push(with_result_of([&]() {
             return tmc::spawn(func(std::move(data))).fork();
           }));
         } else {
           // ProcessFunc is a regular function
-          co_await outChan->post(with_result_of([&]() {
+          co_await outQueue->push(with_result_of([&]() {
             return tmc::spawn([](ProcessFunc f, FInput i) -> tmc::task<Output> {
                      co_return f(std::move(i));
                    }(func, std::move(data)))
@@ -107,12 +107,12 @@ struct pipeline_stage {
         if constexpr (tmc::traits::is_awaitable<
                         std::invoke_result_t<ProcessFunc, FInput&&>>) {
           // ProcessFunc is a coroutine
-          co_await outChan->post(with_result_of([&]() {
+          co_await outQueue->push(with_result_of([&]() {
             return tmc::spawn(func(std::move(input.get()))).fork();
           }));
         } else {
           // ProcessFunc is a regular function
-          co_await outChan->post(with_result_of([&]() {
+          co_await outQueue->push(with_result_of([&]() {
             return tmc::spawn([](ProcessFunc f, FInput i) -> tmc::task<Output> {
                      co_return f(std::move(i));
                    }(func, std::move(input.get())))
@@ -124,35 +124,35 @@ struct pipeline_stage {
 
     // Input queue is closed and drained. Close the output queue so the
     // downstream stage knows no more elements are coming.
-    outChan->close();
+    outQueue->close();
   }
 
   pipeline_stage(
-    tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> inChan,
+    tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> inQueue,
     ProcessFunc func, size_t parallelism
   )
-      : outChan_(make_pipeline_queue<output_t>(parallelism)) {
-    fg.fork(worker(inChan, outChan_, func));
+      : output_queue(make_pipeline_queue<output_t>(parallelism)) {
+    fg.fork(worker(inQueue, output_queue, func));
   }
 
-  pipeline_queue_ptr<output_t> get_channel() { return outChan_; }
+  pipeline_queue_ptr<output_t> get_queue() { return output_queue; }
 };
 
 // The start stage is a normal pipeline_stage that additionally owns its
 // input queue and exposes it as the public `in` member, so the driver has
-// somewhere to post the initial elements.
+// somewhere to push the initial elements.
 template <typename Input, typename Output, typename ProcessFunc>
 struct pipeline_start_stage : pipeline_stage<Input, Output, ProcessFunc> {
-  pipeline_queue_ptr<Input> in;
+  pipeline_queue_ptr<Input> input_queue;
 
   pipeline_start_stage(
-    tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> inChan,
+    tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> inQueue,
     ProcessFunc func, size_t parallelism
   )
       : pipeline_stage<Input, Output, ProcessFunc>(
-          fg, inChan, func, parallelism
+          fg, inQueue, func, parallelism
         ),
-        in(std::move(inChan)) {}
+        input_queue(std::move(inQueue)) {}
 };
 
 // Creates the first stage of the pipeline. The driver writes input elements
@@ -168,9 +168,9 @@ auto start_pipeline(
     tmc::traits::awaitable_result_t<Intermediate>, Intermediate>;
   // The input queue is sized to `parallelism` to give the driver buffering
   // proportional to the stage's processing capacity.
-  auto inChan = make_pipeline_queue<Input>(parallelism);
+  auto inQueue = make_pipeline_queue<Input>(parallelism);
   return pipeline_start_stage<Input, Output, Func>{
-    fg, std::move(inChan), transformFunc, parallelism
+    fg, std::move(inQueue), transformFunc, parallelism
   };
 }
 
@@ -190,7 +190,7 @@ auto pipeline_transform(
     tmc::traits::is_awaitable<IntermediateOutput>,
     tmc::traits::awaitable_result_t<IntermediateOutput>, IntermediateOutput>;
   return pipeline_stage<Input, Output, Func>{
-    fg, from.get_channel(), transformFunc, parallelism
+    fg, from.get_queue(), transformFunc, parallelism
   };
 }
 
@@ -199,8 +199,8 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
   // consumer task, avoiding the internal queue and fork overhead entirely.
   template <typename CInput>
   static tmc::task<void>
-  inline_worker(pipeline_queue_ptr<CInput> inChan, ProcessFunc func) {
-    while (auto input = co_await inChan->pull()) {
+  inline_worker(pipeline_queue_ptr<CInput> inQueue, ProcessFunc func) {
+    while (auto input = co_await inQueue->pull()) {
       if constexpr (tmc::traits::is_awaitable<CInput>) {
         auto data = co_await std::move(input.get());
         using FInput = tmc::traits::awaitable_result_t<CInput>;
@@ -224,7 +224,7 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
 
   template <typename CInput>
   static tmc::task<void> worker(
-    pipeline_queue_ptr<CInput> inChan, ProcessFunc func, size_t parallelism
+    pipeline_queue_ptr<CInput> inQueue, ProcessFunc func, size_t parallelism
   ) {
     // Each in-flight consume runs as its own forked task. The internal
     // bounded queue holds those fork handles so we can await them in FIFO
@@ -235,15 +235,15 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
 
     // Track the number of currently active (in-flight) consume tasks in
     // a separate size_t. This lets us drain exactly when we hit the
-    // parallelism limit, so the next post() never blocks on a full queue.
+    // parallelism limit, so the next push() never blocks on a full queue.
     size_t active = 0;
 
-    while (auto input = co_await inChan->pull()) {
+    while (auto input = co_await inQueue->pull()) {
       if constexpr (tmc::traits::is_awaitable<CInput>) {
         // Upstream queue contains forked task handles - await to get value.
         auto data = co_await std::move(input.get());
         using FInput = tmc::traits::awaitable_result_t<CInput>;
-        co_await internalQueue->post(with_result_of([&]() {
+        co_await internalQueue->push(with_result_of([&]() {
           return tmc::spawn([](ProcessFunc f, FInput d) -> tmc::task<void> {
                    if constexpr (tmc::traits::is_awaitable<std::invoke_result_t<
                                    ProcessFunc, FInput&&>>) {
@@ -258,7 +258,7 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
       } else {
         using FInput = CInput;
         // Upstream queue contains values directly.
-        co_await internalQueue->post(with_result_of([&]() {
+        co_await internalQueue->push(with_result_of([&]() {
           return tmc::spawn([](ProcessFunc f, FInput d) -> tmc::task<void> {
                    if constexpr (tmc::traits::is_awaitable<std::invoke_result_t<
                                    ProcessFunc, FInput&&>>) {
@@ -274,7 +274,7 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
       ++active;
 
       // Hit the parallelism limit - drain one completion (in FIFO order)
-      // before the next iteration's post() could otherwise block.
+      // before the next iteration's push() could otherwise block.
       if (active >= parallelism) {
         auto handle = co_await internalQueue->pull();
         co_await std::move(handle.get());
@@ -291,13 +291,13 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
   }
 
   pipeline_end_stage(
-    tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> inChan,
+    tmc::aw_fork_group<0, void>& fg, pipeline_queue_ptr<Input> inQueue,
     ProcessFunc func, size_t parallelism
   ) {
     if (parallelism == 1) {
-      fg.fork(inline_worker(inChan, func));
+      fg.fork(inline_worker(inQueue, func));
     } else {
-      fg.fork(worker(inChan, func, parallelism));
+      fg.fork(worker(inQueue, func, parallelism));
     }
   }
 };
@@ -314,6 +314,6 @@ auto end_pipeline(
 ) {
   using Input = typename PriorStage::output_t;
   return pipeline_end_stage<Input, Func>{
-    fg, from.get_channel(), consumeFunc, parallelism
+    fg, from.get_queue(), consumeFunc, parallelism
   };
 }

--- a/examples/pipeline_fifo.hpp
+++ b/examples/pipeline_fifo.hpp
@@ -83,7 +83,7 @@ struct pipeline_stage {
   ) {
     while (auto input = co_await inQueue->pull()) {
       if constexpr (tmc::traits::is_awaitable<CInput>) {
-        auto data = co_await std::move(input.get());
+        auto data = co_await std::move(input.value());
         using FInput = tmc::traits::awaitable_result_t<CInput>;
         // The data element in the queue is an awaitable
         if constexpr (tmc::traits::is_awaitable<
@@ -108,14 +108,14 @@ struct pipeline_stage {
                         std::invoke_result_t<ProcessFunc, FInput&&>>) {
           // ProcessFunc is a coroutine
           co_await outQueue->push(with_result_of([&]() {
-            return tmc::spawn(func(std::move(input.get()))).fork();
+            return tmc::spawn(func(std::move(input.value()))).fork();
           }));
         } else {
           // ProcessFunc is a regular function
           co_await outQueue->push(with_result_of([&]() {
             return tmc::spawn([](ProcessFunc f, FInput i) -> tmc::task<Output> {
                      co_return f(std::move(i));
-                   }(func, std::move(input.get())))
+                   }(func, std::move(input.value())))
               .fork();
           }));
         }
@@ -202,7 +202,7 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
   inline_worker(pipeline_queue_ptr<CInput> inQueue, ProcessFunc func) {
     while (auto input = co_await inQueue->pull()) {
       if constexpr (tmc::traits::is_awaitable<CInput>) {
-        auto data = co_await std::move(input.get());
+        auto data = co_await std::move(input.value());
         using FInput = tmc::traits::awaitable_result_t<CInput>;
         if constexpr (tmc::traits::is_awaitable<
                         std::invoke_result_t<ProcessFunc, FInput&&>>) {
@@ -214,9 +214,9 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
         using FInput = CInput;
         if constexpr (tmc::traits::is_awaitable<
                         std::invoke_result_t<ProcessFunc, FInput&&>>) {
-          co_await func(std::move(input.get()));
+          co_await func(std::move(input.value()));
         } else {
-          func(std::move(input.get()));
+          func(std::move(input.value()));
         }
       }
     }
@@ -241,7 +241,7 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
     while (auto input = co_await inQueue->pull()) {
       if constexpr (tmc::traits::is_awaitable<CInput>) {
         // Upstream queue contains forked task handles - await to get value.
-        auto data = co_await std::move(input.get());
+        auto data = co_await std::move(input.value());
         using FInput = tmc::traits::awaitable_result_t<CInput>;
         co_await internalQueue->push(with_result_of([&]() {
           return tmc::spawn([](ProcessFunc f, FInput d) -> tmc::task<void> {
@@ -267,7 +267,7 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
                      f(std::move(d));
                    }
                    co_return;
-                 }(func, std::move(input.get())))
+                 }(func, std::move(input.value())))
             .fork();
         }));
       }
@@ -277,7 +277,7 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
       // before the next iteration's push() could otherwise block.
       if (active >= parallelism) {
         auto handle = co_await internalQueue->pull();
-        co_await std::move(handle.get());
+        co_await std::move(handle.value());
         --active;
       }
     }
@@ -285,7 +285,7 @@ template <typename Input, typename ProcessFunc> struct pipeline_end_stage {
     // Upstream is closed. Drain any remaining in-flight forks in order.
     while (active > 0) {
       auto handle = co_await internalQueue->pull();
-      co_await std::move(handle.get());
+      co_await std::move(handle.value());
       --active;
     }
   }

--- a/examples/queue_bench.cpp
+++ b/examples/queue_bench.cpp
@@ -1,4 +1,4 @@
-// A benchmark for the throughput of tmc::qu_unbounded_spsc / mpsc.
+// A benchmark for the throughput of tmc::qu_spsc_unbounded / mpsc.
 
 #include "tmc/all_headers.hpp"
 
@@ -18,21 +18,21 @@ static_assert(
 );
 
 #if PRODUCER_COUNT == 1
-struct queue_config : tmc::qu_unbounded_spsc_default_config {
+struct queue_config : tmc::qu_spsc_unbounded_default_config {
   //  static inline constexpr bool ConsumerCanSuspend = true;
   //  static inline constexpr size_t BlockSize = 4096;
   //  static inline constexpr size_t PackingLevel = 1;
   //  static inline constexpr bool EmbedFirstBlock = false;
 };
-using queue_t = tmc::qu_unbounded_spsc<size_t, queue_config>;
+using queue_t = tmc::qu_spsc_unbounded<size_t, queue_config>;
 #else
-struct queue_config : tmc::qu_unbounded_mpsc_default_config {
+struct queue_config : tmc::qu_mpsc_unbounded_default_config {
   //  static inline constexpr bool ConsumerCanSuspend = true;
   //  static inline constexpr size_t BlockSize = 4096;
   //  static inline constexpr size_t PackingLevel = 0;
   //  static inline constexpr bool EmbedFirstBlock = false;
 };
-using queue_t = tmc::qu_unbounded_mpsc<size_t, queue_config>;
+using queue_t = tmc::qu_mpsc_unbounded<size_t, queue_config>;
 #endif
 
 struct producer_result {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,9 +134,9 @@ make_exe_base(
   test_misc.cpp
   test_coro_functor.cpp
   test_qu_lockfree.cpp
-  test_qu_unbounded_mpsc.cpp
-  test_qu_unbounded_spsc.cpp
-  test_qu_bounded_spsc.cpp
+  test_qu_mpsc_unbounded.cpp
+  test_qu_spsc_unbounded.cpp
+  test_qu_spsc_bounded.cpp
   test_thread_layout.cpp
   test_fork_group.cpp
   test_spawn_group.cpp

--- a/tests/test_qu_mpsc_unbounded.cpp
+++ b/tests/test_qu_mpsc_unbounded.cpp
@@ -1,12 +1,12 @@
 #include "test_common.hpp"
 #include "tmc/detail/compat.hpp"
-#include "tmc/qu_unbounded_mpsc.hpp"
+#include "tmc/qu_mpsc_unbounded.hpp"
 
 #include <cstddef>
 #include <gtest/gtest.h>
 #include <ranges>
 
-#define CATEGORY test_qu_unbounded_mpsc
+#define CATEGORY test_qu_mpsc_unbounded
 
 class CATEGORY : public testing::Test {
 protected:
@@ -19,7 +19,7 @@ protected:
 
 static constexpr size_t MPSC_TEST_SENTINEL = static_cast<size_t>(-1);
 
-template <size_t Pack> struct q_config : tmc::qu_unbounded_mpsc_default_config {
+template <size_t Pack> struct q_config : tmc::qu_mpsc_unbounded_default_config {
   // Use a small block size to ensure that alloc / reclaim is triggered.
   static inline constexpr size_t BlockSize = 2;
   static inline constexpr size_t PackingLevel = Pack;
@@ -64,7 +64,7 @@ void do_q_test(Executor& Exec) {
         size_t sum;
       };
 
-      auto q = tmc::qu_unbounded_mpsc<size_t, q_config<PackingLevel>>{};
+      auto q = tmc::qu_mpsc_unbounded<size_t, q_config<PackingLevel>>{};
 
       auto results = co_await tmc::spawn_tuple(
         [](auto& Q) -> tmc::task<size_t> {
@@ -106,7 +106,7 @@ void do_q_test(Executor& Exec) {
         size_t sum;
       };
 
-      auto q = tmc::qu_unbounded_mpsc<size_t, q_config<PackingLevel>>{};
+      auto q = tmc::qu_mpsc_unbounded<size_t, q_config<PackingLevel>>{};
 
       auto results = co_await tmc::spawn_tuple(
         [](auto& Q) -> tmc::task<size_t> {
@@ -149,7 +149,7 @@ void do_q_test(Executor& Exec) {
       // destroy q with data remaining inside
       std::atomic<size_t> count;
       {
-        auto q = tmc::qu_unbounded_mpsc<
+        auto q = tmc::qu_mpsc_unbounded<
           mpsc_destructor_counter, q_config<PackingLevel>>{};
         for (size_t i = 0; i < 12; ++i) {
           q.post(mpsc_destructor_counter{&count});
@@ -178,7 +178,7 @@ TEST_F(CATEGORY, post_bulk_none) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
     size_t i = 0;
     for (; i < 4; ++i) {
       q.post_bulk(&i, 0);
@@ -210,8 +210,8 @@ TEST_F(CATEGORY, post_bulk_none) {
 // close() makes subsequent post() return false. Pre-close posts still drain.
 TEST_F(CATEGORY, close_basic_try_pull) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    using qerr = tmc::qu_unbounded_mpsc_err;
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    using qerr = tmc::qu_mpsc_unbounded_err;
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
 
     for (size_t i = 0; i < 5; ++i) {
       EXPECT_TRUE(q.post(i));
@@ -252,8 +252,8 @@ TEST_F(CATEGORY, close_basic_try_pull) {
 // close() with no values posted: try_pull immediately returns CLOSED.
 TEST_F(CATEGORY, close_empty_try_pull) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    using qerr = tmc::qu_unbounded_mpsc_err;
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    using qerr = tmc::qu_mpsc_unbounded_err;
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
     q.close();
 
     auto v = q.try_pull();
@@ -266,7 +266,7 @@ TEST_F(CATEGORY, close_empty_try_pull) {
 // close() is idempotent.
 TEST_F(CATEGORY, close_idempotent) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
     q.close();
     q.close();
     q.close();
@@ -278,7 +278,7 @@ TEST_F(CATEGORY, close_idempotent) {
 // pull() resumes with an empty scope when the queue is closed and drained.
 TEST_F(CATEGORY, close_pull_drains_then_returns_empty) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
 
     for (size_t i = 0; i < 3; ++i) {
       EXPECT_TRUE(q.post(i));
@@ -307,7 +307,7 @@ TEST_F(CATEGORY, close_pull_drains_then_returns_empty) {
 // CLOSED sentinel at slot 0, which wakes the consumer with an empty scope.
 TEST_F(CATEGORY, close_wakes_suspended_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
 
     auto results = co_await tmc::spawn_tuple(
       [](auto& Q) -> tmc::task<bool> {
@@ -333,7 +333,7 @@ TEST_F(CATEGORY, close_wakes_suspended_consumer) {
 // post_bulk() returns false when called after close.
 TEST_F(CATEGORY, close_post_bulk_returns_false) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
     q.close();
 
     size_t vals[3] = {10, 11, 12};
@@ -347,7 +347,7 @@ TEST_F(CATEGORY, close_post_bulk_returns_false) {
 TEST_F(CATEGORY, close_concurrent_producer) {
   test_async_main(ex(), []() -> tmc::task<void> {
     static constexpr size_t NITEMS = 2000;
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
     std::atomic<size_t> posted_ok{0};
 
     auto results = co_await tmc::spawn_tuple(
@@ -391,8 +391,8 @@ TEST_F(CATEGORY, close_concurrent_producer) {
 // and pre-close posts still drain.
 TEST_F(CATEGORY, close_resume_inline_basic_try_pull) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    using qerr = tmc::qu_unbounded_mpsc_err;
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    using qerr = tmc::qu_mpsc_unbounded_err;
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
 
     for (size_t i = 0; i < 5; ++i) {
       EXPECT_TRUE(q.post(i));
@@ -433,8 +433,8 @@ TEST_F(CATEGORY, close_resume_inline_basic_try_pull) {
 // CLOSED.
 TEST_F(CATEGORY, close_resume_inline_empty_try_pull) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    using qerr = tmc::qu_unbounded_mpsc_err;
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    using qerr = tmc::qu_mpsc_unbounded_err;
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
     q.close_resume_inline();
 
     auto v = q.try_pull();
@@ -447,7 +447,7 @@ TEST_F(CATEGORY, close_resume_inline_empty_try_pull) {
 // close_resume_inline() is idempotent and may be intermixed with close().
 TEST_F(CATEGORY, close_resume_inline_idempotent) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
     q.close_resume_inline();
     q.close_resume_inline();
     q.close();
@@ -461,7 +461,7 @@ TEST_F(CATEGORY, close_resume_inline_idempotent) {
 // drained.
 TEST_F(CATEGORY, close_resume_inline_pull_drains_then_returns_empty) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
 
     for (size_t i = 0; i < 3; ++i) {
       EXPECT_TRUE(q.post(i));
@@ -491,7 +491,7 @@ TEST_F(CATEGORY, close_resume_inline_pull_drains_then_returns_empty) {
 // 0, which wakes the consumer with an empty scope.
 TEST_F(CATEGORY, close_resume_inline_wakes_suspended_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
 
     auto results = co_await tmc::spawn_tuple(
       [](auto& Q) -> tmc::task<bool> {
@@ -519,15 +519,15 @@ TEST_F(CATEGORY, close_resume_inline_wakes_suspended_consumer) {
 // Config that uses the default ConsumerCanSuspend = false. This exercises
 // the non-suspending code path in write_element (set_data_ready()), which
 // q_config<> overrides to true and which is otherwise never tested.
-struct q_config_no_suspend : tmc::qu_unbounded_mpsc_default_config {
+struct q_config_no_suspend : tmc::qu_mpsc_unbounded_default_config {
   static inline constexpr size_t BlockSize = 2;
   // ConsumerCanSuspend defaults to false
 };
 
 TEST_F(CATEGORY, no_suspend_try_pull_only) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    using qerr = tmc::qu_unbounded_mpsc_err;
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config_no_suspend>{};
+    using qerr = tmc::qu_mpsc_unbounded_err;
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config_no_suspend>{};
 
     // No data available yet: try_pull returns EMPTY.
     {
@@ -570,10 +570,10 @@ TEST_F(CATEGORY, no_suspend_try_pull_only) {
   }());
 }
 
-// EmbedFirstBlock = true: first block is embedded in the qu_unbounded_mpsc
+// EmbedFirstBlock = true: first block is embedded in the qu_mpsc_unbounded
 // object. Push and reclaim past the embedded block to ensure the destructor
 // handles the embedded-vs-heap distinction correctly.
-struct q_config_embed : tmc::qu_unbounded_mpsc_default_config {
+struct q_config_embed : tmc::qu_mpsc_unbounded_default_config {
   static inline constexpr size_t BlockSize = 2;
   static inline constexpr bool EmbedFirstBlock = true;
   static inline constexpr bool ConsumerCanSuspend = true;
@@ -581,7 +581,7 @@ struct q_config_embed : tmc::qu_unbounded_mpsc_default_config {
 
 TEST_F(CATEGORY, embed_first_block) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config_embed>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config_embed>{};
     static constexpr size_t NITEMS = 50; // many block transitions
     size_t sum = 0;
     for (size_t i = 0; i < NITEMS; ++i) {
@@ -604,7 +604,7 @@ TEST_F(CATEGORY, embed_first_block) {
     std::atomic<size_t> count{0};
     {
       auto q =
-        tmc::qu_unbounded_mpsc<mpsc_destructor_counter, q_config_embed>{};
+        tmc::qu_mpsc_unbounded<mpsc_destructor_counter, q_config_embed>{};
       // 2 items fit in the embedded block (BlockSize=2). Add more to also
       // exercise heap blocks alongside the embedded block.
       for (size_t i = 0; i < 5; ++i) {
@@ -623,7 +623,7 @@ TEST_F(CATEGORY, multi_producer) {
     static constexpr size_t PER_PRODUCER = 500;
     static constexpr size_t TOTAL = NPRODUCERS * PER_PRODUCER;
 
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
 
     auto results = co_await tmc::spawn_tuple(
       [](auto& Q) -> tmc::task<size_t> {
@@ -682,7 +682,7 @@ TEST_F(CATEGORY, try_pull_zc_scope_move) {
     {
       std::atomic<size_t> count{0};
       {
-        auto q = tmc::qu_unbounded_mpsc<mpsc_destructor_counter, q_config<0>>{};
+        auto q = tmc::qu_mpsc_unbounded<mpsc_destructor_counter, q_config<0>>{};
         q.post(mpsc_destructor_counter{&count});
         q.post(mpsc_destructor_counter{&count});
         q.post(mpsc_destructor_counter{&count});
@@ -695,7 +695,7 @@ TEST_F(CATEGORY, try_pull_zc_scope_move) {
         EXPECT_NE(v2->count, nullptr);
         // v1's destructor must be a no-op; only v2's release the slot.
       } // v2 destructor releases slot 0; remaining 2 destroyed by
-        // ~qu_unbounded_mpsc
+        // ~qu_mpsc_unbounded
       EXPECT_EQ(count.load(), 3);
     }
 
@@ -703,7 +703,7 @@ TEST_F(CATEGORY, try_pull_zc_scope_move) {
     {
       std::atomic<size_t> count{0};
       {
-        using qu = tmc::qu_unbounded_mpsc<mpsc_destructor_counter, q_config<0>>;
+        using qu = tmc::qu_mpsc_unbounded<mpsc_destructor_counter, q_config<0>>;
         qu q{};
         q.post(mpsc_destructor_counter{&count});
         q.post(mpsc_destructor_counter{&count});
@@ -732,8 +732,8 @@ TEST_F(CATEGORY, try_pull_zc_scope_move_assign_over_nonempty) {
     std::atomic<size_t> count1{0};
     std::atomic<size_t> count2{0};
     {
-      auto q1 = tmc::qu_unbounded_mpsc<mpsc_destructor_counter, q_config<0>>{};
-      auto q2 = tmc::qu_unbounded_mpsc<mpsc_destructor_counter, q_config<0>>{};
+      auto q1 = tmc::qu_mpsc_unbounded<mpsc_destructor_counter, q_config<0>>{};
+      auto q2 = tmc::qu_mpsc_unbounded<mpsc_destructor_counter, q_config<0>>{};
       q1.post(mpsc_destructor_counter{&count1});
       q2.post(mpsc_destructor_counter{&count2});
 
@@ -766,7 +766,7 @@ TEST_F(CATEGORY, try_pull_zc_scope_self_move_assign) {
   test_async_main(ex(), []() -> tmc::task<void> {
     std::atomic<size_t> count{0};
     {
-      auto q = tmc::qu_unbounded_mpsc<mpsc_destructor_counter, q_config<0>>{};
+      auto q = tmc::qu_mpsc_unbounded<mpsc_destructor_counter, q_config<0>>{};
       q.post(mpsc_destructor_counter{&count});
 
       auto v = q.try_pull();
@@ -788,8 +788,8 @@ TEST_F(CATEGORY, try_pull_zc_scope_self_move_assign) {
 // Explicit EMPTY status before close().
 TEST_F(CATEGORY, try_pull_empty_status) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    using qerr = tmc::qu_unbounded_mpsc_err;
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    using qerr = tmc::qu_mpsc_unbounded_err;
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
 
     {
       auto v = q.try_pull();
@@ -819,7 +819,7 @@ TEST_F(CATEGORY, close_concurrent_post_bulk) {
   test_async_main(ex(), []() -> tmc::task<void> {
     static constexpr size_t NBULKS = 200;
     static constexpr size_t BULK_SIZE = 7;
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
     std::atomic<size_t> posted_ok{0};
 
     auto results = co_await tmc::spawn_tuple(
@@ -872,7 +872,7 @@ struct mpsc_multi_arg {
 // post() forwards variadic arguments and constructs T in-place.
 TEST_F(CATEGORY, post_variadic_args) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto q = tmc::qu_unbounded_mpsc<mpsc_multi_arg, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<mpsc_multi_arg, q_config<0>>{};
 
     // Single-argument form: construct from an existing T.
     EXPECT_TRUE(q.post(mpsc_multi_arg{1, 2, 3}));
@@ -911,7 +911,7 @@ TEST_F(CATEGORY, post_variadic_args) {
 // post_bulk(Begin, End) iterator-pair overload.
 TEST_F(CATEGORY, post_bulk_iter_pair) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
 
     std::vector<size_t> vals;
     for (size_t i = 0; i < 10; ++i) {
@@ -939,7 +939,7 @@ TEST_F(CATEGORY, post_bulk_iter_pair) {
 // post_bulk(Range) range overload.
 TEST_F(CATEGORY, post_bulk_range) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
 
     std::vector<size_t> vals;
     for (size_t i = 0; i < 10; ++i) {
@@ -967,7 +967,7 @@ TEST_F(CATEGORY, post_bulk_range) {
 // All 3 post_bulk forms accept zero-element inputs and become no-ops.
 TEST_F(CATEGORY, post_bulk_empty_all_forms) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto q = tmc::qu_unbounded_mpsc<size_t, q_config<0>>{};
+    auto q = tmc::qu_mpsc_unbounded<size_t, q_config<0>>{};
 
     // (iter, count) form with count == 0.
     size_t dummy = 0;

--- a/tests/test_qu_spsc_bounded.cpp
+++ b/tests/test_qu_spsc_bounded.cpp
@@ -21,7 +21,7 @@ protected:
 static constexpr size_t SPSC_TEST_SENTINEL = static_cast<size_t>(-1);
 
 // Default capacity used by tests below. Must be large enough to hold the
-// largest bulk post in any single call (post_bulk requires Count <= capacity).
+// largest bulk push in any single call (push_bulk requires Count <= capacity).
 static constexpr size_t TEST_CAPACITY = 128;
 
 template <size_t Pack> struct qu_config : tmc::qu_spsc_bounded_default_config {
@@ -74,9 +74,9 @@ void do_chan_test(Executor& Exec) {
         [](auto& Chan) -> tmc::task<size_t> {
           size_t i = 0;
           for (; i < NITEMS; ++i) {
-            co_await Chan.post(i);
+            co_await Chan.push(i);
           }
-          co_await Chan.post(SPSC_TEST_SENTINEL);
+          co_await Chan.push(SPSC_TEST_SENTINEL);
           co_return i;
         }(chan),
         [](auto& Chan) -> tmc::task<result> {
@@ -103,7 +103,7 @@ void do_chan_test(Executor& Exec) {
       EXPECT_EQ(expectedSum, cons.sum);
     }
     {
-      // general test - post_bulk
+      // general test - push_bulk
       static constexpr size_t NITEMS = 1000;
       struct result {
         size_t count;
@@ -121,7 +121,7 @@ void do_chan_test(Executor& Exec) {
             if (j > NITEMS) {
               j = NITEMS;
             }
-            co_await Chan.post_bulk(std::ranges::views::iota(i).begin(), j - i);
+            co_await Chan.push_bulk(std::ranges::views::iota(i).begin(), j - i);
           }
           co_return i;
         }(chan),
@@ -157,7 +157,7 @@ void do_chan_test(Executor& Exec) {
         auto chan = tmc::qu_spsc_bounded<
           spsc_destructor_counter, qu_config<PackingLevel>>{TEST_CAPACITY};
         for (size_t i = 0; i < 12; ++i) {
-          co_await chan.post(spsc_destructor_counter{&count});
+          co_await chan.push(spsc_destructor_counter{&count});
         }
 
         for (size_t i = 0; i < 7; ++i) {
@@ -178,22 +178,22 @@ TEST_F(CATEGORY, config_sweep) {
   do_chan_test<1>(ex());
 }
 
-// Test post_bulk of 0 items
-TEST_F(CATEGORY, post_bulk_none) {
+// Test push_bulk of 0 items
+TEST_F(CATEGORY, push_bulk_none) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
     auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
     size_t i = 0;
     for (; i < 4; ++i) {
-      co_await chan.post_bulk(&i, 0);
-      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
-      co_await chan.post(i);
+      co_await chan.push_bulk(&i, 0);
+      co_await chan.push_bulk(std::ranges::views::iota(i).begin(), 0);
+      co_await chan.push(i);
     }
     for (; i < 8; ++i) {
-      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
-      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
-      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 1);
+      co_await chan.push_bulk(std::ranges::views::iota(i).begin(), 0);
+      co_await chan.push_bulk(std::ranges::views::iota(i).begin(), 0);
+      co_await chan.push_bulk(std::ranges::views::iota(i).begin(), 1);
     }
     size_t count = 0;
     size_t sum = 0;
@@ -231,10 +231,10 @@ TEST_F(CATEGORY, try_pull_no_suspend) {
       EXPECT_FALSE(static_cast<bool>(v));
     }
 
-    // Post enough items to exercise the queue.
+    // Push enough items to exercise the queue.
     static constexpr size_t NITEMS = 10;
     for (size_t i = 0; i < NITEMS; ++i) {
-      co_await chan.post(i);
+      co_await chan.push(i);
     }
 
     size_t sum = 0;
@@ -262,7 +262,7 @@ TEST_F(CATEGORY, try_pull_no_suspend) {
 }
 
 // A type with no default, copy, or move constructor. Can only be created
-// in-place via post()'s emplace forwarding.
+// in-place via push()'s emplace forwarding.
 struct non_movable {
   int value;
 
@@ -288,9 +288,9 @@ TEST_F(CATEGORY, non_movable_type) {
     }
 
     // Emplace-construct values directly in the queue storage.
-    co_await chan.post(1, 2);
-    co_await chan.post(3, 4);
-    co_await chan.post(5, 6);
+    co_await chan.push(1, 2);
+    co_await chan.push(3, 4);
+    co_await chan.push(5, 6);
 
     // First value via try_pull
     {
@@ -386,8 +386,8 @@ TEST_F(CATEGORY, try_pull_zc_scope_move_assign_over_nonempty) {
       auto q2 = tmc::qu_spsc_bounded<spsc_destructor_counter, qu_config<0>>{
         TEST_CAPACITY
       };
-      co_await q1.post(spsc_destructor_counter{&count1});
-      co_await q2.post(spsc_destructor_counter{&count2});
+      co_await q1.push(spsc_destructor_counter{&count1});
+      co_await q2.push(spsc_destructor_counter{&count2});
 
       auto v1 = q1.try_pull();
       EXPECT_TRUE(static_cast<bool>(v1));
@@ -412,7 +412,7 @@ TEST_F(CATEGORY, try_pull_zc_scope_move_assign_over_nonempty) {
 }
 
 // close() wakes a consumer suspended on an empty slot. The consumer is parked
-// at slot 0 (no producer has posted), then close() races in and publishes the
+// at slot 0 (no producer has pushed), then close() races in and publishes the
 // CLOSED sentinel at slot 0, returning the waiting consumer pointer which
 // close() then resumes.
 TEST_F(CATEGORY, close_wakes_suspended_consumer) {
@@ -440,16 +440,16 @@ TEST_F(CATEGORY, close_wakes_suspended_consumer) {
   }());
 }
 
-// post_bulk() wakes a consumer suspended on the slot it writes. Exercises
-// the branch in post_bulk that captures the waiting consumer pointer
-// returned by write_element and posts its resumption.
-TEST_F(CATEGORY, post_bulk_wakes_suspended_consumer) {
+// push_bulk() wakes a consumer suspended on the slot it writes. Exercises
+// the branch in push_bulk that captures the waiting consumer pointer
+// returned by write_element and pushs its resumption.
+TEST_F(CATEGORY, push_bulk_wakes_suspended_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
     auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     auto results = co_await tmc::spawn_tuple(
       [](auto& Chan) -> tmc::task<size_t> {
-        // Consumer suspends at slot 0; post_bulk wakes it. Drain everything
+        // Consumer suspends at slot 0; push_bulk wakes it. Drain everything
         // until the queue is closed (empty scope). Each pull_zc_scope must
         // be released before the next pull() runs, since the queue requires
         // that at most one scope from a given queue be live at a time.
@@ -465,7 +465,7 @@ TEST_F(CATEGORY, post_bulk_wakes_suspended_consumer) {
           co_await tmc::reschedule();
         }
         size_t items[5] = {10, 20, 30, 40, 50};
-        co_await Chan.post_bulk(&items[0], 5);
+        co_await Chan.push_bulk(&items[0], 5);
         Chan.close();
         co_return;
       }(chan)
@@ -477,14 +477,14 @@ TEST_F(CATEGORY, post_bulk_wakes_suspended_consumer) {
 }
 
 // close_resume_inline() with no waiting consumer: behaves like close() in
-// that subsequent posts must not be used, and pre-close posts can still drain.
+// that subsequent pushs must not be used, and pre-close pushs can still drain.
 TEST_F(CATEGORY, close_resume_inline_no_waiting_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
     using qerr = tmc::qu_spsc_bounded_err;
     auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     for (size_t i = 0; i < 5; ++i) {
-      co_await chan.post(i);
+      co_await chan.push(i);
     }
 
     chan.close_resume_inline();
@@ -520,7 +520,7 @@ TEST_F(CATEGORY, close_resume_inline_no_waiting_consumer) {
 }
 
 // close_resume_inline() wakes a consumer suspended on an empty slot, just like
-// close() does. The consumer is parked at slot 0 (no producer has posted),
+// close() does. The consumer is parked at slot 0 (no producer has pushed),
 // then close_resume_inline() races in and publishes the CLOSED sentinel at slot
 // 0, which wakes the consumer (resumed inline) with an empty scope.
 TEST_F(CATEGORY, close_resume_inline_wakes_suspended_consumer) {
@@ -582,16 +582,16 @@ TEST_F(CATEGORY, pull_after_closed) {
   }());
 }
 
-// post_bulk(Begin, End) iterator-pair overload: pushes [Begin, End) into the
+// push_bulk(Begin, End) iterator-pair overload: pushes [Begin, End) into the
 // queue and drains them in order.
-TEST_F(CATEGORY, post_bulk_iterator_pair) {
+TEST_F(CATEGORY, push_bulk_iterator_pair) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
     auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     std::vector<size_t> items{1, 2, 3, 4, 5, 6, 7};
-    co_await chan.post_bulk(items.begin(), items.end());
+    co_await chan.push_bulk(items.begin(), items.end());
 
     size_t sum = 0;
     size_t count = 0;
@@ -611,22 +611,22 @@ TEST_F(CATEGORY, post_bulk_iterator_pair) {
   }());
 }
 
-// post_bulk(Begin, End) with Begin == End must be a no-op.
-TEST_F(CATEGORY, post_bulk_iterator_pair_empty) {
+// push_bulk(Begin, End) with Begin == End must be a no-op.
+TEST_F(CATEGORY, push_bulk_iterator_pair_empty) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
     auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     std::vector<size_t> empty_items;
-    co_await chan.post_bulk(empty_items.begin(), empty_items.end());
+    co_await chan.push_bulk(empty_items.begin(), empty_items.end());
 
     // Queue should still be empty.
     auto v = chan.try_pull();
     EXPECT_FALSE(static_cast<bool>(v));
 
-    // A real post afterwards should still work and arrive at slot 0.
-    co_await chan.post(42u);
+    // A real push afterwards should still work and arrive at slot 0.
+    co_await chan.push(42u);
     auto v2 = chan.try_pull();
     EXPECT_TRUE(static_cast<bool>(v2));
     EXPECT_EQ(42u, *v2);
@@ -634,16 +634,16 @@ TEST_F(CATEGORY, post_bulk_iterator_pair_empty) {
   }());
 }
 
-// post_bulk(Range) overload: pushes the range into the queue and drains in
+// push_bulk(Range) overload: pushes the range into the queue and drains in
 // order.
-TEST_F(CATEGORY, post_bulk_range) {
+TEST_F(CATEGORY, push_bulk_range) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
     auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     std::vector<size_t> items{10, 20, 30, 40, 50};
-    co_await chan.post_bulk(items);
+    co_await chan.push_bulk(items);
 
     size_t sum = 0;
     size_t count = 0;
@@ -663,10 +663,10 @@ TEST_F(CATEGORY, post_bulk_range) {
   }());
 }
 
-// post() wakes a consumer suspended on the slot it writes. Exercises the
-// branch in aw_post_impl::await_resume that captures the waiting consumer
-// pointer returned by write_element and posts its resumption.
-TEST_F(CATEGORY, post_wakes_suspended_consumer) {
+// push() wakes a consumer suspended on the slot it writes. Exercises the
+// branch in aw_push_impl::await_resume that captures the waiting consumer
+// pointer returned by write_element and pushs its resumption.
+TEST_F(CATEGORY, push_wakes_suspended_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
     auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
@@ -683,8 +683,8 @@ TEST_F(CATEGORY, post_wakes_suspended_consumer) {
         for (size_t i = 0; i < 10; ++i) {
           co_await tmc::reschedule();
         }
-        co_await Chan.post(123u);
-        co_await Chan.post(456u);
+        co_await Chan.push(123u);
+        co_await Chan.push(456u);
         Chan.close();
         co_return;
       }(chan)
@@ -695,12 +695,12 @@ TEST_F(CATEGORY, post_wakes_suspended_consumer) {
   }());
 }
 
-// Fill the queue to capacity, then have the producer attempt one more post()
+// Fill the queue to capacity, then have the producer attempt one more push()
 // which must suspend until the consumer drains. Exercises
-// aw_post_impl::await_suspend (producer suspension on a DATA_BIT slot) and
+// aw_push_impl::await_suspend (producer suspension on a DATA_BIT slot) and
 // finish_read's branch that wakes a producer when prev flags is a
 // producer_base*.
-TEST_F(CATEGORY, post_suspends_when_full) {
+TEST_F(CATEGORY, push_suspends_when_full) {
   test_async_main(ex(), []() -> tmc::task<void> {
     // Tiny capacity so we can easily fill the queue.
     static constexpr size_t CAP = 4;
@@ -711,8 +711,8 @@ TEST_F(CATEGORY, post_suspends_when_full) {
       [](auto& Chan) -> tmc::task<size_t> {
         size_t sum = 0;
         for (size_t i = 0; i < NITEMS; ++i) {
-          // Each post may suspend once the queue fills up.
-          co_await Chan.post(i);
+          // Each push may suspend once the queue fills up.
+          co_await Chan.push(i);
           sum += i;
         }
         co_return sum;
@@ -742,10 +742,10 @@ TEST_F(CATEGORY, post_suspends_when_full) {
   }());
 }
 
-// Fill the queue to capacity, then have the producer attempt a post_bulk()
-// that does not fit. Exercises aw_post_bulk_impl::await_suspend (producer
+// Fill the queue to capacity, then have the producer attempt a push_bulk()
+// that does not fit. Exercises aw_push_bulk_impl::await_suspend (producer
 // suspension on a full bulk slot) and the finish_read wake-producer branch.
-TEST_F(CATEGORY, post_bulk_suspends_when_full) {
+TEST_F(CATEGORY, push_bulk_suspends_when_full) {
   test_async_main(ex(), []() -> tmc::task<void> {
     static constexpr size_t CAP = 4;
     auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{CAP};
@@ -754,15 +754,15 @@ TEST_F(CATEGORY, post_bulk_suspends_when_full) {
       [](auto& Chan) -> tmc::task<size_t> {
         size_t items[CAP] = {1, 2, 3, 4};
         // First fill the queue exactly.
-        co_await Chan.post_bulk(&items[0], CAP);
-        // This second post_bulk cannot fit any element; producer must
+        co_await Chan.push_bulk(&items[0], CAP);
+        // This second push_bulk cannot fit any element; producer must
         // suspend until the consumer drains the queue.
         size_t more[CAP] = {10, 20, 30, 40};
-        co_await Chan.post_bulk(&more[0], CAP);
+        co_await Chan.push_bulk(&more[0], CAP);
         co_return 1u + 2u + 3u + 4u + 10u + 20u + 30u + 40u;
       }(chan),
       [](auto& Chan) -> tmc::task<size_t> {
-        // Give the producer time to fill and then suspend on post_bulk.
+        // Give the producer time to fill and then suspend on push_bulk.
         for (size_t i = 0; i < 20; ++i) {
           co_await tmc::reschedule();
         }
@@ -781,7 +781,7 @@ TEST_F(CATEGORY, post_bulk_suspends_when_full) {
   }());
 }
 
-// empty() returns true on an empty queue and false after a post; returns true
+// empty() returns true on an empty queue and false after a push; returns true
 // again after a try_pull drains the slot. Exercises empty() and the
 // is_data_waiting() helper.
 TEST_F(CATEGORY, empty_method) {
@@ -791,7 +791,7 @@ TEST_F(CATEGORY, empty_method) {
     auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
     EXPECT_TRUE(chan.empty());
 
-    co_await chan.post(7u);
+    co_await chan.push(7u);
     EXPECT_FALSE(chan.empty());
 
     {
@@ -803,7 +803,7 @@ TEST_F(CATEGORY, empty_method) {
 
     // Bulk fill, then drain.
     size_t items[3] = {100, 200, 300};
-    co_await chan.post_bulk(&items[0], 3);
+    co_await chan.push_bulk(&items[0], 3);
     EXPECT_FALSE(chan.empty());
     {
       auto v = chan.try_pull();
@@ -824,22 +824,22 @@ TEST_F(CATEGORY, empty_method) {
   }());
 }
 
-// post_bulk(Range) with an empty range must be a no-op.
-TEST_F(CATEGORY, post_bulk_range_empty) {
+// push_bulk(Range) with an empty range must be a no-op.
+TEST_F(CATEGORY, push_bulk_range_empty) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
     auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     std::vector<size_t> empty_items;
-    co_await chan.post_bulk(empty_items);
+    co_await chan.push_bulk(empty_items);
 
     // Queue should still be empty.
     auto v = chan.try_pull();
     EXPECT_FALSE(static_cast<bool>(v));
 
-    // A real post afterwards should still work and arrive at slot 0.
-    co_await chan.post(99u);
+    // A real push afterwards should still work and arrive at slot 0.
+    co_await chan.push(99u);
     auto v2 = chan.try_pull();
     EXPECT_TRUE(static_cast<bool>(v2));
     EXPECT_EQ(99u, *v2);

--- a/tests/test_qu_spsc_bounded.cpp
+++ b/tests/test_qu_spsc_bounded.cpp
@@ -1,13 +1,13 @@
 #include "test_common.hpp"
 #include "tmc/detail/compat.hpp"
-#include "tmc/qu_unbounded_spsc.hpp"
+#include "tmc/qu_spsc_bounded.hpp"
 
 #include <cstddef>
 #include <gtest/gtest.h>
 #include <ranges>
 #include <vector>
 
-#define CATEGORY test_qu_unbounded_spsc
+#define CATEGORY test_qu_spsc_bounded
 
 class CATEGORY : public testing::Test {
 protected:
@@ -20,10 +20,11 @@ protected:
 
 static constexpr size_t SPSC_TEST_SENTINEL = static_cast<size_t>(-1);
 
-template <size_t Pack>
-struct qu_config : tmc::qu_unbounded_spsc_default_config {
-  // Use a small block size to ensure that alloc / reclaim is triggered.
-  static inline constexpr size_t BlockSize = 2;
+// Default capacity used by tests below. Must be large enough to hold the
+// largest bulk post in any single call (post_bulk requires Count <= capacity).
+static constexpr size_t TEST_CAPACITY = 128;
+
+template <size_t Pack> struct qu_config : tmc::qu_spsc_bounded_default_config {
   static inline constexpr size_t PackingLevel = Pack;
   static inline constexpr bool ConsumerCanSuspend = true;
 };
@@ -66,15 +67,16 @@ void do_chan_test(Executor& Exec) {
         size_t sum;
       };
 
-      auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<PackingLevel>>{};
+      auto chan =
+        tmc::qu_spsc_bounded<size_t, qu_config<PackingLevel>>{TEST_CAPACITY};
 
       auto results = co_await tmc::spawn_tuple(
         [](auto& Chan) -> tmc::task<size_t> {
           size_t i = 0;
           for (; i < NITEMS; ++i) {
-            Chan.post(i);
+            co_await Chan.post(i);
           }
-          Chan.post(SPSC_TEST_SENTINEL);
+          co_await Chan.post(SPSC_TEST_SENTINEL);
           co_return i;
         }(chan),
         [](auto& Chan) -> tmc::task<result> {
@@ -108,7 +110,8 @@ void do_chan_test(Executor& Exec) {
         size_t sum;
       };
 
-      auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<PackingLevel>>{};
+      auto chan =
+        tmc::qu_spsc_bounded<size_t, qu_config<PackingLevel>>{TEST_CAPACITY};
 
       auto results = co_await tmc::spawn_tuple(
         [](auto& Chan) -> tmc::task<size_t> {
@@ -118,7 +121,7 @@ void do_chan_test(Executor& Exec) {
             if (j > NITEMS) {
               j = NITEMS;
             }
-            Chan.post_bulk(std::ranges::views::iota(i).begin(), j - i);
+            co_await Chan.post_bulk(std::ranges::views::iota(i).begin(), j - i);
           }
           co_return i;
         }(chan),
@@ -151,10 +154,10 @@ void do_chan_test(Executor& Exec) {
       // destroy chan with data remaining inside
       std::atomic<size_t> count;
       {
-        auto chan = tmc::qu_unbounded_spsc<
-          spsc_destructor_counter, qu_config<PackingLevel>>{};
+        auto chan = tmc::qu_spsc_bounded<
+          spsc_destructor_counter, qu_config<PackingLevel>>{TEST_CAPACITY};
         for (size_t i = 0; i < 12; ++i) {
-          chan.post(spsc_destructor_counter{&count});
+          co_await chan.post(spsc_destructor_counter{&count});
         }
 
         for (size_t i = 0; i < 7; ++i) {
@@ -180,17 +183,17 @@ TEST_F(CATEGORY, post_bulk_none) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<0>>{};
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
     size_t i = 0;
     for (; i < 4; ++i) {
-      chan.post_bulk(&i, 0);
-      chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
-      chan.post(i);
+      co_await chan.post_bulk(&i, 0);
+      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
+      co_await chan.post(i);
     }
     for (; i < 8; ++i) {
-      chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
-      chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
-      chan.post_bulk(std::ranges::views::iota(i).begin(), 1);
+      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
+      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
+      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 1);
     }
     size_t count = 0;
     size_t sum = 0;
@@ -209,8 +212,7 @@ TEST_F(CATEGORY, post_bulk_none) {
   }());
 }
 
-struct chan_config_no_suspend : tmc::qu_unbounded_spsc_default_config {
-  static inline constexpr size_t BlockSize = 2;
+struct chan_config_no_suspend : tmc::qu_spsc_bounded_default_config {
   static inline constexpr bool ConsumerCanSuspend = false;
 };
 
@@ -220,7 +222,8 @@ TEST_F(CATEGORY, try_pull_no_suspend) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_spsc<size_t, chan_config_no_suspend>{};
+    auto chan =
+      tmc::qu_spsc_bounded<size_t, chan_config_no_suspend>{TEST_CAPACITY};
 
     // Empty queue: try_pull yields an empty scope.
     {
@@ -228,10 +231,10 @@ TEST_F(CATEGORY, try_pull_no_suspend) {
       EXPECT_FALSE(static_cast<bool>(v));
     }
 
-    // Post enough items to cross several blocks.
+    // Post enough items to exercise the queue.
     static constexpr size_t NITEMS = 10;
     for (size_t i = 0; i < NITEMS; ++i) {
-      chan.post(i);
+      co_await chan.post(i);
     }
 
     size_t sum = 0;
@@ -276,7 +279,7 @@ TEST_F(CATEGORY, non_movable_type) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_spsc<non_movable, qu_config<0>>{};
+    auto chan = tmc::qu_spsc_bounded<non_movable, qu_config<0>>{TEST_CAPACITY};
 
     // try_pull on empty queue
     {
@@ -285,9 +288,9 @@ TEST_F(CATEGORY, non_movable_type) {
     }
 
     // Emplace-construct values directly in the queue storage.
-    chan.post(1, 2);
-    chan.post(3, 4);
-    chan.post(5, 6);
+    co_await chan.post(1, 2);
+    co_await chan.post(3, 4);
+    co_await chan.post(5, 6);
 
     // First value via try_pull
     {
@@ -324,8 +327,8 @@ TEST_F(CATEGORY, try_pull_closed_empty) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    using qerr = tmc::qu_unbounded_spsc_err;
-    auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<0>>{};
+    using qerr = tmc::qu_spsc_bounded_err;
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
     chan.close();
 
     auto v = chan.try_pull();
@@ -340,7 +343,7 @@ TEST_F(CATEGORY, close_idempotent) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<0>>{};
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
     chan.close();
     chan.close();
     chan.close();
@@ -354,7 +357,7 @@ TEST_F(CATEGORY, pull_after_close_returns_empty) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<0>>{};
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
     chan.close();
 
     auto v = co_await chan.pull();
@@ -377,10 +380,14 @@ TEST_F(CATEGORY, try_pull_zc_scope_move_assign_over_nonempty) {
     std::atomic<size_t> count1{0};
     std::atomic<size_t> count2{0};
     {
-      auto q1 = tmc::qu_unbounded_spsc<spsc_destructor_counter, qu_config<0>>{};
-      auto q2 = tmc::qu_unbounded_spsc<spsc_destructor_counter, qu_config<0>>{};
-      q1.post(spsc_destructor_counter{&count1});
-      q2.post(spsc_destructor_counter{&count2});
+      auto q1 = tmc::qu_spsc_bounded<spsc_destructor_counter, qu_config<0>>{
+        TEST_CAPACITY
+      };
+      auto q2 = tmc::qu_spsc_bounded<spsc_destructor_counter, qu_config<0>>{
+        TEST_CAPACITY
+      };
+      co_await q1.post(spsc_destructor_counter{&count1});
+      co_await q2.post(spsc_destructor_counter{&count2});
 
       auto v1 = q1.try_pull();
       EXPECT_TRUE(static_cast<bool>(v1));
@@ -410,7 +417,7 @@ TEST_F(CATEGORY, try_pull_zc_scope_move_assign_over_nonempty) {
 // close() then resumes.
 TEST_F(CATEGORY, close_wakes_suspended_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<0>>{};
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     auto results = co_await tmc::spawn_tuple(
       [](auto& Chan) -> tmc::task<bool> {
@@ -438,7 +445,7 @@ TEST_F(CATEGORY, close_wakes_suspended_consumer) {
 // returned by write_element and posts its resumption.
 TEST_F(CATEGORY, post_bulk_wakes_suspended_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<0>>{};
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     auto results = co_await tmc::spawn_tuple(
       [](auto& Chan) -> tmc::task<size_t> {
@@ -458,7 +465,7 @@ TEST_F(CATEGORY, post_bulk_wakes_suspended_consumer) {
           co_await tmc::reschedule();
         }
         size_t items[5] = {10, 20, 30, 40, 50};
-        Chan.post_bulk(&items[0], 5);
+        co_await Chan.post_bulk(&items[0], 5);
         Chan.close();
         co_return;
       }(chan)
@@ -473,11 +480,11 @@ TEST_F(CATEGORY, post_bulk_wakes_suspended_consumer) {
 // that subsequent posts must not be used, and pre-close posts can still drain.
 TEST_F(CATEGORY, close_resume_inline_no_waiting_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    using qerr = tmc::qu_unbounded_spsc_err;
-    auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<0>>{};
+    using qerr = tmc::qu_spsc_bounded_err;
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     for (size_t i = 0; i < 5; ++i) {
-      chan.post(i);
+      co_await chan.post(i);
     }
 
     chan.close_resume_inline();
@@ -518,7 +525,7 @@ TEST_F(CATEGORY, close_resume_inline_no_waiting_consumer) {
 // 0, which wakes the consumer (resumed inline) with an empty scope.
 TEST_F(CATEGORY, close_resume_inline_wakes_suspended_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<0>>{};
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     auto results = co_await tmc::spawn_tuple(
       [](auto& Chan) -> tmc::task<bool> {
@@ -543,16 +550,48 @@ TEST_F(CATEGORY, close_resume_inline_wakes_suspended_consumer) {
   }());
 }
 
+TEST_F(CATEGORY, pull_after_closed) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    using qerr = tmc::qu_spsc_bounded_err;
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
+
+    co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<void> {
+        // Suspend on the empty cutoff slot.
+        auto v = co_await Chan.pull();
+        EXPECT_FALSE(static_cast<bool>(v)); // woken by close, empty.
+
+        // Now poll the same slot. Per the close() contract this must
+        // immediately return CLOSED again.
+        auto v2 = Chan.try_pull();
+        EXPECT_EQ(qerr::CLOSED, v2.status());
+        EXPECT_EQ(false, v2.has_value());
+        auto v3 = co_await Chan.pull();
+        EXPECT_EQ(false, v3.has_value());
+      }(chan),
+      [](auto& Chan) -> tmc::task<void> {
+        // Yield to give the consumer a chance to suspend.
+        for (size_t i = 0; i < 10; ++i) {
+          co_await tmc::reschedule();
+        }
+        Chan.close();
+      }(chan)
+    );
+
+    co_return;
+  }());
+}
+
 // post_bulk(Begin, End) iterator-pair overload: pushes [Begin, End) into the
 // queue and drains them in order.
 TEST_F(CATEGORY, post_bulk_iterator_pair) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<0>>{};
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     std::vector<size_t> items{1, 2, 3, 4, 5, 6, 7};
-    chan.post_bulk(items.begin(), items.end());
+    co_await chan.post_bulk(items.begin(), items.end());
 
     size_t sum = 0;
     size_t count = 0;
@@ -577,17 +616,17 @@ TEST_F(CATEGORY, post_bulk_iterator_pair_empty) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<0>>{};
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     std::vector<size_t> empty_items;
-    chan.post_bulk(empty_items.begin(), empty_items.end());
+    co_await chan.post_bulk(empty_items.begin(), empty_items.end());
 
     // Queue should still be empty.
     auto v = chan.try_pull();
     EXPECT_FALSE(static_cast<bool>(v));
 
     // A real post afterwards should still work and arrive at slot 0.
-    chan.post(42u);
+    co_await chan.post(42u);
     auto v2 = chan.try_pull();
     EXPECT_TRUE(static_cast<bool>(v2));
     EXPECT_EQ(42u, *v2);
@@ -601,10 +640,10 @@ TEST_F(CATEGORY, post_bulk_range) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<0>>{};
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     std::vector<size_t> items{10, 20, 30, 40, 50};
-    chan.post_bulk(items);
+    co_await chan.post_bulk(items);
 
     size_t sum = 0;
     size_t count = 0;
@@ -624,22 +663,183 @@ TEST_F(CATEGORY, post_bulk_range) {
   }());
 }
 
+// post() wakes a consumer suspended on the slot it writes. Exercises the
+// branch in aw_post_impl::await_resume that captures the waiting consumer
+// pointer returned by write_element and posts its resumption.
+TEST_F(CATEGORY, post_wakes_suspended_consumer) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
+
+    auto results = co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<size_t> {
+        size_t sum = 0;
+        while (auto v = co_await Chan.pull()) {
+          sum += *v;
+        }
+        co_return sum;
+      }(chan),
+      [](auto& Chan) -> tmc::task<void> {
+        // Yield to give the consumer a chance to suspend.
+        for (size_t i = 0; i < 10; ++i) {
+          co_await tmc::reschedule();
+        }
+        co_await Chan.post(123u);
+        co_await Chan.post(456u);
+        Chan.close();
+        co_return;
+      }(chan)
+    );
+
+    EXPECT_EQ(123u + 456u, std::get<0>(results));
+    co_return;
+  }());
+}
+
+// Fill the queue to capacity, then have the producer attempt one more post()
+// which must suspend until the consumer drains. Exercises
+// aw_post_impl::await_suspend (producer suspension on a DATA_BIT slot) and
+// finish_read's branch that wakes a producer when prev flags is a
+// producer_base*.
+TEST_F(CATEGORY, post_suspends_when_full) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    // Tiny capacity so we can easily fill the queue.
+    static constexpr size_t CAP = 4;
+    static constexpr size_t NITEMS = 32;
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{CAP};
+
+    auto results = co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<size_t> {
+        size_t sum = 0;
+        for (size_t i = 0; i < NITEMS; ++i) {
+          // Each post may suspend once the queue fills up.
+          co_await Chan.post(i);
+          sum += i;
+        }
+        co_return sum;
+      }(chan),
+      [](auto& Chan) -> tmc::task<size_t> {
+        // Give the producer time to fill the queue and suspend.
+        for (size_t i = 0; i < 20; ++i) {
+          co_await tmc::reschedule();
+        }
+        size_t sum = 0;
+        for (size_t i = 0; i < NITEMS; ++i) {
+          auto v = co_await Chan.pull();
+          EXPECT_TRUE(static_cast<bool>(v));
+          sum += *v;
+        }
+        co_return sum;
+      }(chan)
+    );
+
+    size_t expected = 0;
+    for (size_t i = 0; i < NITEMS; ++i) {
+      expected += i;
+    }
+    EXPECT_EQ(expected, std::get<0>(results));
+    EXPECT_EQ(expected, std::get<1>(results));
+    co_return;
+  }());
+}
+
+// Fill the queue to capacity, then have the producer attempt a post_bulk()
+// that does not fit. Exercises aw_post_bulk_impl::await_suspend (producer
+// suspension on a full bulk slot) and the finish_read wake-producer branch.
+TEST_F(CATEGORY, post_bulk_suspends_when_full) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    static constexpr size_t CAP = 4;
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{CAP};
+
+    auto results = co_await tmc::spawn_tuple(
+      [](auto& Chan) -> tmc::task<size_t> {
+        size_t items[CAP] = {1, 2, 3, 4};
+        // First fill the queue exactly.
+        co_await Chan.post_bulk(&items[0], CAP);
+        // This second post_bulk cannot fit any element; producer must
+        // suspend until the consumer drains the queue.
+        size_t more[CAP] = {10, 20, 30, 40};
+        co_await Chan.post_bulk(&more[0], CAP);
+        co_return 1u + 2u + 3u + 4u + 10u + 20u + 30u + 40u;
+      }(chan),
+      [](auto& Chan) -> tmc::task<size_t> {
+        // Give the producer time to fill and then suspend on post_bulk.
+        for (size_t i = 0; i < 20; ++i) {
+          co_await tmc::reschedule();
+        }
+        size_t sum = 0;
+        for (size_t i = 0; i < 2 * CAP; ++i) {
+          auto v = co_await Chan.pull();
+          EXPECT_TRUE(static_cast<bool>(v));
+          sum += *v;
+        }
+        co_return sum;
+      }(chan)
+    );
+
+    EXPECT_EQ(std::get<0>(results), std::get<1>(results));
+    co_return;
+  }());
+}
+
+// empty() returns true on an empty queue and false after a post; returns true
+// again after a try_pull drains the slot. Exercises empty() and the
+// is_data_waiting() helper.
+TEST_F(CATEGORY, empty_method) {
+  tmc::ex_cpu ex;
+  ex.set_thread_count(1).init();
+  test_async_main(ex, []() -> tmc::task<void> {
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
+    EXPECT_TRUE(chan.empty());
+
+    co_await chan.post(7u);
+    EXPECT_FALSE(chan.empty());
+
+    {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+      EXPECT_EQ(7u, *v);
+    }
+    EXPECT_TRUE(chan.empty());
+
+    // Bulk fill, then drain.
+    size_t items[3] = {100, 200, 300};
+    co_await chan.post_bulk(&items[0], 3);
+    EXPECT_FALSE(chan.empty());
+    {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+    }
+    EXPECT_FALSE(chan.empty());
+    {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+    }
+    EXPECT_FALSE(chan.empty());
+    {
+      auto v = chan.try_pull();
+      EXPECT_TRUE(static_cast<bool>(v));
+    }
+    EXPECT_TRUE(chan.empty());
+    co_return;
+  }());
+}
+
 // post_bulk(Range) with an empty range must be a no-op.
 TEST_F(CATEGORY, post_bulk_range_empty) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_unbounded_spsc<size_t, qu_config<0>>{};
+    auto chan = tmc::qu_spsc_bounded<size_t, qu_config<0>>{TEST_CAPACITY};
 
     std::vector<size_t> empty_items;
-    chan.post_bulk(empty_items);
+    co_await chan.post_bulk(empty_items);
 
     // Queue should still be empty.
     auto v = chan.try_pull();
     EXPECT_FALSE(static_cast<bool>(v));
 
     // A real post afterwards should still work and arrive at slot 0.
-    chan.post(99u);
+    co_await chan.post(99u);
     auto v2 = chan.try_pull();
     EXPECT_TRUE(static_cast<bool>(v2));
     EXPECT_EQ(99u, *v2);

--- a/tests/test_qu_spsc_unbounded.cpp
+++ b/tests/test_qu_spsc_unbounded.cpp
@@ -1,13 +1,13 @@
 #include "test_common.hpp"
 #include "tmc/detail/compat.hpp"
-#include "tmc/qu_bounded_spsc.hpp"
+#include "tmc/qu_spsc_unbounded.hpp"
 
 #include <cstddef>
 #include <gtest/gtest.h>
 #include <ranges>
 #include <vector>
 
-#define CATEGORY test_qu_bounded_spsc
+#define CATEGORY test_qu_spsc_unbounded
 
 class CATEGORY : public testing::Test {
 protected:
@@ -20,11 +20,10 @@ protected:
 
 static constexpr size_t SPSC_TEST_SENTINEL = static_cast<size_t>(-1);
 
-// Default capacity used by tests below. Must be large enough to hold the
-// largest bulk post in any single call (post_bulk requires Count <= capacity).
-static constexpr size_t TEST_CAPACITY = 128;
-
-template <size_t Pack> struct qu_config : tmc::qu_bounded_spsc_default_config {
+template <size_t Pack>
+struct qu_config : tmc::qu_spsc_unbounded_default_config {
+  // Use a small block size to ensure that alloc / reclaim is triggered.
+  static inline constexpr size_t BlockSize = 2;
   static inline constexpr size_t PackingLevel = Pack;
   static inline constexpr bool ConsumerCanSuspend = true;
 };
@@ -67,16 +66,15 @@ void do_chan_test(Executor& Exec) {
         size_t sum;
       };
 
-      auto chan =
-        tmc::qu_bounded_spsc<size_t, qu_config<PackingLevel>>{TEST_CAPACITY};
+      auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<PackingLevel>>{};
 
       auto results = co_await tmc::spawn_tuple(
         [](auto& Chan) -> tmc::task<size_t> {
           size_t i = 0;
           for (; i < NITEMS; ++i) {
-            co_await Chan.post(i);
+            Chan.post(i);
           }
-          co_await Chan.post(SPSC_TEST_SENTINEL);
+          Chan.post(SPSC_TEST_SENTINEL);
           co_return i;
         }(chan),
         [](auto& Chan) -> tmc::task<result> {
@@ -110,8 +108,7 @@ void do_chan_test(Executor& Exec) {
         size_t sum;
       };
 
-      auto chan =
-        tmc::qu_bounded_spsc<size_t, qu_config<PackingLevel>>{TEST_CAPACITY};
+      auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<PackingLevel>>{};
 
       auto results = co_await tmc::spawn_tuple(
         [](auto& Chan) -> tmc::task<size_t> {
@@ -121,7 +118,7 @@ void do_chan_test(Executor& Exec) {
             if (j > NITEMS) {
               j = NITEMS;
             }
-            co_await Chan.post_bulk(std::ranges::views::iota(i).begin(), j - i);
+            Chan.post_bulk(std::ranges::views::iota(i).begin(), j - i);
           }
           co_return i;
         }(chan),
@@ -154,10 +151,10 @@ void do_chan_test(Executor& Exec) {
       // destroy chan with data remaining inside
       std::atomic<size_t> count;
       {
-        auto chan = tmc::qu_bounded_spsc<
-          spsc_destructor_counter, qu_config<PackingLevel>>{TEST_CAPACITY};
+        auto chan = tmc::qu_spsc_unbounded<
+          spsc_destructor_counter, qu_config<PackingLevel>>{};
         for (size_t i = 0; i < 12; ++i) {
-          co_await chan.post(spsc_destructor_counter{&count});
+          chan.post(spsc_destructor_counter{&count});
         }
 
         for (size_t i = 0; i < 7; ++i) {
@@ -183,17 +180,17 @@ TEST_F(CATEGORY, post_bulk_none) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<0>>{};
     size_t i = 0;
     for (; i < 4; ++i) {
-      co_await chan.post_bulk(&i, 0);
-      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
-      co_await chan.post(i);
+      chan.post_bulk(&i, 0);
+      chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
+      chan.post(i);
     }
     for (; i < 8; ++i) {
-      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
-      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
-      co_await chan.post_bulk(std::ranges::views::iota(i).begin(), 1);
+      chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
+      chan.post_bulk(std::ranges::views::iota(i).begin(), 0);
+      chan.post_bulk(std::ranges::views::iota(i).begin(), 1);
     }
     size_t count = 0;
     size_t sum = 0;
@@ -212,7 +209,8 @@ TEST_F(CATEGORY, post_bulk_none) {
   }());
 }
 
-struct chan_config_no_suspend : tmc::qu_bounded_spsc_default_config {
+struct chan_config_no_suspend : tmc::qu_spsc_unbounded_default_config {
+  static inline constexpr size_t BlockSize = 2;
   static inline constexpr bool ConsumerCanSuspend = false;
 };
 
@@ -222,8 +220,7 @@ TEST_F(CATEGORY, try_pull_no_suspend) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan =
-      tmc::qu_bounded_spsc<size_t, chan_config_no_suspend>{TEST_CAPACITY};
+    auto chan = tmc::qu_spsc_unbounded<size_t, chan_config_no_suspend>{};
 
     // Empty queue: try_pull yields an empty scope.
     {
@@ -231,10 +228,10 @@ TEST_F(CATEGORY, try_pull_no_suspend) {
       EXPECT_FALSE(static_cast<bool>(v));
     }
 
-    // Post enough items to exercise the queue.
+    // Post enough items to cross several blocks.
     static constexpr size_t NITEMS = 10;
     for (size_t i = 0; i < NITEMS; ++i) {
-      co_await chan.post(i);
+      chan.post(i);
     }
 
     size_t sum = 0;
@@ -279,7 +276,7 @@ TEST_F(CATEGORY, non_movable_type) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_bounded_spsc<non_movable, qu_config<0>>{TEST_CAPACITY};
+    auto chan = tmc::qu_spsc_unbounded<non_movable, qu_config<0>>{};
 
     // try_pull on empty queue
     {
@@ -288,9 +285,9 @@ TEST_F(CATEGORY, non_movable_type) {
     }
 
     // Emplace-construct values directly in the queue storage.
-    co_await chan.post(1, 2);
-    co_await chan.post(3, 4);
-    co_await chan.post(5, 6);
+    chan.post(1, 2);
+    chan.post(3, 4);
+    chan.post(5, 6);
 
     // First value via try_pull
     {
@@ -327,8 +324,8 @@ TEST_F(CATEGORY, try_pull_closed_empty) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    using qerr = tmc::qu_bounded_spsc_err;
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    using qerr = tmc::qu_spsc_unbounded_err;
+    auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<0>>{};
     chan.close();
 
     auto v = chan.try_pull();
@@ -343,7 +340,7 @@ TEST_F(CATEGORY, close_idempotent) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<0>>{};
     chan.close();
     chan.close();
     chan.close();
@@ -357,7 +354,7 @@ TEST_F(CATEGORY, pull_after_close_returns_empty) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<0>>{};
     chan.close();
 
     auto v = co_await chan.pull();
@@ -380,14 +377,10 @@ TEST_F(CATEGORY, try_pull_zc_scope_move_assign_over_nonempty) {
     std::atomic<size_t> count1{0};
     std::atomic<size_t> count2{0};
     {
-      auto q1 = tmc::qu_bounded_spsc<spsc_destructor_counter, qu_config<0>>{
-        TEST_CAPACITY
-      };
-      auto q2 = tmc::qu_bounded_spsc<spsc_destructor_counter, qu_config<0>>{
-        TEST_CAPACITY
-      };
-      co_await q1.post(spsc_destructor_counter{&count1});
-      co_await q2.post(spsc_destructor_counter{&count2});
+      auto q1 = tmc::qu_spsc_unbounded<spsc_destructor_counter, qu_config<0>>{};
+      auto q2 = tmc::qu_spsc_unbounded<spsc_destructor_counter, qu_config<0>>{};
+      q1.post(spsc_destructor_counter{&count1});
+      q2.post(spsc_destructor_counter{&count2});
 
       auto v1 = q1.try_pull();
       EXPECT_TRUE(static_cast<bool>(v1));
@@ -417,7 +410,7 @@ TEST_F(CATEGORY, try_pull_zc_scope_move_assign_over_nonempty) {
 // close() then resumes.
 TEST_F(CATEGORY, close_wakes_suspended_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<0>>{};
 
     auto results = co_await tmc::spawn_tuple(
       [](auto& Chan) -> tmc::task<bool> {
@@ -445,7 +438,7 @@ TEST_F(CATEGORY, close_wakes_suspended_consumer) {
 // returned by write_element and posts its resumption.
 TEST_F(CATEGORY, post_bulk_wakes_suspended_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<0>>{};
 
     auto results = co_await tmc::spawn_tuple(
       [](auto& Chan) -> tmc::task<size_t> {
@@ -465,7 +458,7 @@ TEST_F(CATEGORY, post_bulk_wakes_suspended_consumer) {
           co_await tmc::reschedule();
         }
         size_t items[5] = {10, 20, 30, 40, 50};
-        co_await Chan.post_bulk(&items[0], 5);
+        Chan.post_bulk(&items[0], 5);
         Chan.close();
         co_return;
       }(chan)
@@ -480,11 +473,11 @@ TEST_F(CATEGORY, post_bulk_wakes_suspended_consumer) {
 // that subsequent posts must not be used, and pre-close posts can still drain.
 TEST_F(CATEGORY, close_resume_inline_no_waiting_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    using qerr = tmc::qu_bounded_spsc_err;
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    using qerr = tmc::qu_spsc_unbounded_err;
+    auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<0>>{};
 
     for (size_t i = 0; i < 5; ++i) {
-      co_await chan.post(i);
+      chan.post(i);
     }
 
     chan.close_resume_inline();
@@ -525,7 +518,7 @@ TEST_F(CATEGORY, close_resume_inline_no_waiting_consumer) {
 // 0, which wakes the consumer (resumed inline) with an empty scope.
 TEST_F(CATEGORY, close_resume_inline_wakes_suspended_consumer) {
   test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<0>>{};
 
     auto results = co_await tmc::spawn_tuple(
       [](auto& Chan) -> tmc::task<bool> {
@@ -550,48 +543,16 @@ TEST_F(CATEGORY, close_resume_inline_wakes_suspended_consumer) {
   }());
 }
 
-TEST_F(CATEGORY, pull_after_closed) {
-  test_async_main(ex(), []() -> tmc::task<void> {
-    using qerr = tmc::qu_bounded_spsc_err;
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
-
-    co_await tmc::spawn_tuple(
-      [](auto& Chan) -> tmc::task<void> {
-        // Suspend on the empty cutoff slot.
-        auto v = co_await Chan.pull();
-        EXPECT_FALSE(static_cast<bool>(v)); // woken by close, empty.
-
-        // Now poll the same slot. Per the close() contract this must
-        // immediately return CLOSED again.
-        auto v2 = Chan.try_pull();
-        EXPECT_EQ(qerr::CLOSED, v2.status());
-        EXPECT_EQ(false, v2.has_value());
-        auto v3 = co_await Chan.pull();
-        EXPECT_EQ(false, v3.has_value());
-      }(chan),
-      [](auto& Chan) -> tmc::task<void> {
-        // Yield to give the consumer a chance to suspend.
-        for (size_t i = 0; i < 10; ++i) {
-          co_await tmc::reschedule();
-        }
-        Chan.close();
-      }(chan)
-    );
-
-    co_return;
-  }());
-}
-
 // post_bulk(Begin, End) iterator-pair overload: pushes [Begin, End) into the
 // queue and drains them in order.
 TEST_F(CATEGORY, post_bulk_iterator_pair) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<0>>{};
 
     std::vector<size_t> items{1, 2, 3, 4, 5, 6, 7};
-    co_await chan.post_bulk(items.begin(), items.end());
+    chan.post_bulk(items.begin(), items.end());
 
     size_t sum = 0;
     size_t count = 0;
@@ -616,17 +577,17 @@ TEST_F(CATEGORY, post_bulk_iterator_pair_empty) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<0>>{};
 
     std::vector<size_t> empty_items;
-    co_await chan.post_bulk(empty_items.begin(), empty_items.end());
+    chan.post_bulk(empty_items.begin(), empty_items.end());
 
     // Queue should still be empty.
     auto v = chan.try_pull();
     EXPECT_FALSE(static_cast<bool>(v));
 
     // A real post afterwards should still work and arrive at slot 0.
-    co_await chan.post(42u);
+    chan.post(42u);
     auto v2 = chan.try_pull();
     EXPECT_TRUE(static_cast<bool>(v2));
     EXPECT_EQ(42u, *v2);
@@ -640,10 +601,10 @@ TEST_F(CATEGORY, post_bulk_range) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<0>>{};
 
     std::vector<size_t> items{10, 20, 30, 40, 50};
-    co_await chan.post_bulk(items);
+    chan.post_bulk(items);
 
     size_t sum = 0;
     size_t count = 0;
@@ -663,183 +624,22 @@ TEST_F(CATEGORY, post_bulk_range) {
   }());
 }
 
-// post() wakes a consumer suspended on the slot it writes. Exercises the
-// branch in aw_post_impl::await_resume that captures the waiting consumer
-// pointer returned by write_element and posts its resumption.
-TEST_F(CATEGORY, post_wakes_suspended_consumer) {
-  test_async_main(ex(), []() -> tmc::task<void> {
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
-
-    auto results = co_await tmc::spawn_tuple(
-      [](auto& Chan) -> tmc::task<size_t> {
-        size_t sum = 0;
-        while (auto v = co_await Chan.pull()) {
-          sum += *v;
-        }
-        co_return sum;
-      }(chan),
-      [](auto& Chan) -> tmc::task<void> {
-        // Yield to give the consumer a chance to suspend.
-        for (size_t i = 0; i < 10; ++i) {
-          co_await tmc::reschedule();
-        }
-        co_await Chan.post(123u);
-        co_await Chan.post(456u);
-        Chan.close();
-        co_return;
-      }(chan)
-    );
-
-    EXPECT_EQ(123u + 456u, std::get<0>(results));
-    co_return;
-  }());
-}
-
-// Fill the queue to capacity, then have the producer attempt one more post()
-// which must suspend until the consumer drains. Exercises
-// aw_post_impl::await_suspend (producer suspension on a DATA_BIT slot) and
-// finish_read's branch that wakes a producer when prev flags is a
-// producer_base*.
-TEST_F(CATEGORY, post_suspends_when_full) {
-  test_async_main(ex(), []() -> tmc::task<void> {
-    // Tiny capacity so we can easily fill the queue.
-    static constexpr size_t CAP = 4;
-    static constexpr size_t NITEMS = 32;
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{CAP};
-
-    auto results = co_await tmc::spawn_tuple(
-      [](auto& Chan) -> tmc::task<size_t> {
-        size_t sum = 0;
-        for (size_t i = 0; i < NITEMS; ++i) {
-          // Each post may suspend once the queue fills up.
-          co_await Chan.post(i);
-          sum += i;
-        }
-        co_return sum;
-      }(chan),
-      [](auto& Chan) -> tmc::task<size_t> {
-        // Give the producer time to fill the queue and suspend.
-        for (size_t i = 0; i < 20; ++i) {
-          co_await tmc::reschedule();
-        }
-        size_t sum = 0;
-        for (size_t i = 0; i < NITEMS; ++i) {
-          auto v = co_await Chan.pull();
-          EXPECT_TRUE(static_cast<bool>(v));
-          sum += *v;
-        }
-        co_return sum;
-      }(chan)
-    );
-
-    size_t expected = 0;
-    for (size_t i = 0; i < NITEMS; ++i) {
-      expected += i;
-    }
-    EXPECT_EQ(expected, std::get<0>(results));
-    EXPECT_EQ(expected, std::get<1>(results));
-    co_return;
-  }());
-}
-
-// Fill the queue to capacity, then have the producer attempt a post_bulk()
-// that does not fit. Exercises aw_post_bulk_impl::await_suspend (producer
-// suspension on a full bulk slot) and the finish_read wake-producer branch.
-TEST_F(CATEGORY, post_bulk_suspends_when_full) {
-  test_async_main(ex(), []() -> tmc::task<void> {
-    static constexpr size_t CAP = 4;
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{CAP};
-
-    auto results = co_await tmc::spawn_tuple(
-      [](auto& Chan) -> tmc::task<size_t> {
-        size_t items[CAP] = {1, 2, 3, 4};
-        // First fill the queue exactly.
-        co_await Chan.post_bulk(&items[0], CAP);
-        // This second post_bulk cannot fit any element; producer must
-        // suspend until the consumer drains the queue.
-        size_t more[CAP] = {10, 20, 30, 40};
-        co_await Chan.post_bulk(&more[0], CAP);
-        co_return 1u + 2u + 3u + 4u + 10u + 20u + 30u + 40u;
-      }(chan),
-      [](auto& Chan) -> tmc::task<size_t> {
-        // Give the producer time to fill and then suspend on post_bulk.
-        for (size_t i = 0; i < 20; ++i) {
-          co_await tmc::reschedule();
-        }
-        size_t sum = 0;
-        for (size_t i = 0; i < 2 * CAP; ++i) {
-          auto v = co_await Chan.pull();
-          EXPECT_TRUE(static_cast<bool>(v));
-          sum += *v;
-        }
-        co_return sum;
-      }(chan)
-    );
-
-    EXPECT_EQ(std::get<0>(results), std::get<1>(results));
-    co_return;
-  }());
-}
-
-// empty() returns true on an empty queue and false after a post; returns true
-// again after a try_pull drains the slot. Exercises empty() and the
-// is_data_waiting() helper.
-TEST_F(CATEGORY, empty_method) {
-  tmc::ex_cpu ex;
-  ex.set_thread_count(1).init();
-  test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
-    EXPECT_TRUE(chan.empty());
-
-    co_await chan.post(7u);
-    EXPECT_FALSE(chan.empty());
-
-    {
-      auto v = chan.try_pull();
-      EXPECT_TRUE(static_cast<bool>(v));
-      EXPECT_EQ(7u, *v);
-    }
-    EXPECT_TRUE(chan.empty());
-
-    // Bulk fill, then drain.
-    size_t items[3] = {100, 200, 300};
-    co_await chan.post_bulk(&items[0], 3);
-    EXPECT_FALSE(chan.empty());
-    {
-      auto v = chan.try_pull();
-      EXPECT_TRUE(static_cast<bool>(v));
-    }
-    EXPECT_FALSE(chan.empty());
-    {
-      auto v = chan.try_pull();
-      EXPECT_TRUE(static_cast<bool>(v));
-    }
-    EXPECT_FALSE(chan.empty());
-    {
-      auto v = chan.try_pull();
-      EXPECT_TRUE(static_cast<bool>(v));
-    }
-    EXPECT_TRUE(chan.empty());
-    co_return;
-  }());
-}
-
 // post_bulk(Range) with an empty range must be a no-op.
 TEST_F(CATEGORY, post_bulk_range_empty) {
   tmc::ex_cpu ex;
   ex.set_thread_count(1).init();
   test_async_main(ex, []() -> tmc::task<void> {
-    auto chan = tmc::qu_bounded_spsc<size_t, qu_config<0>>{TEST_CAPACITY};
+    auto chan = tmc::qu_spsc_unbounded<size_t, qu_config<0>>{};
 
     std::vector<size_t> empty_items;
-    co_await chan.post_bulk(empty_items);
+    chan.post_bulk(empty_items);
 
     // Queue should still be empty.
     auto v = chan.try_pull();
     EXPECT_FALSE(static_cast<bool>(v));
 
     // A real post afterwards should still work and arrive at slot 0.
-    co_await chan.post(99u);
+    chan.post(99u);
     auto v2 = chan.try_pull();
     EXPECT_TRUE(static_cast<bool>(v2));
     EXPECT_EQ(99u, *v2);


### PR DESCRIPTION
Rename all 3 of the recently added queues:

qu_unbounded_mpsc -> qu_mpsc_unbounded
qu_unbounded_spsc -> qu_spsc_unbounded
qu_bounded_spsc -> qu_spsc_bounded

Goes with https://github.com/tzcnt/TooManyCooks/pull/232