### PR TITLE
don't spin in tests

### DIFF
--- a/tests/test_channel.cpp
+++ b/tests/test_channel.cpp
@@ -182,7 +182,7 @@ void do_chan_test(
       }
       {
         // destroy chan with data remaining inside
-        std::atomic<size_t> count;
+        std::atomic<size_t> count{0};
         {
           auto chan =
             tmc::make_channel<destructor_counter, chan_config<PackingLevel>>()
@@ -710,13 +710,15 @@ TEST_F(CATEGORY, close_and_drain_wait_idempotent) {
     drainer.drain_wait();
   });
 
-  test_async_main(ex(), [consumer = chan.new_token()]() mutable -> tmc::task<void> {
-    size_t count = 0;
-    while (co_await consumer.pull()) {
-      ++count;
-    }
-    EXPECT_EQ(count, 3u);
-  }());
+  test_async_main(
+    ex(), [consumer = chan.new_token()]() mutable -> tmc::task<void> {
+      size_t count = 0;
+      while (co_await consumer.pull()) {
+        ++count;
+      }
+      EXPECT_EQ(count, 3u);
+    }()
+  );
 
   closer.join();
 }

--- a/tests/test_misc.cpp
+++ b/tests/test_misc.cpp
@@ -61,7 +61,7 @@ TEST_F(CATEGORY, post_bulk_checked_default_executor) {
 }
 
 TEST_F(CATEGORY, tiny_vec_resize_zero) {
-  std::atomic<size_t> count;
+  std::atomic<size_t> count{0};
   tmc::detail::tiny_vec<destructor_counter> tv;
   tv.resize(2);
   tv.emplace_at(0, &count);

--- a/tests/test_qu_mpsc_unbounded.cpp
+++ b/tests/test_qu_mpsc_unbounded.cpp
@@ -129,7 +129,7 @@ void do_q_test(Executor& Exec) {
           for (size_t i = 0; i < NITEMS; ++i) {
             auto v = Q.try_pull();
             while (!v) {
-              TMC_CPU_PAUSE();
+              co_await tmc::reschedule();
               v = Q.try_pull();
             }
             ++count;
@@ -150,7 +150,7 @@ void do_q_test(Executor& Exec) {
     }
     {
       // destroy q with data remaining inside
-      std::atomic<size_t> count;
+      std::atomic<size_t> count{0};
       {
         auto q = tmc::qu_mpsc_unbounded<
           mpsc_destructor_counter, q_config<PackingLevel>>{};

--- a/tests/test_qu_spsc_bounded.cpp
+++ b/tests/test_qu_spsc_bounded.cpp
@@ -134,7 +134,7 @@ void do_chan_test(Executor& Exec) {
           for (size_t i = 0; i < NITEMS; ++i) {
             auto v = Chan.try_pull();
             while (!v) {
-              TMC_CPU_PAUSE();
+              co_await tmc::reschedule();
               v = Chan.try_pull();
             }
             ++count;
@@ -155,7 +155,7 @@ void do_chan_test(Executor& Exec) {
     }
     {
       // destroy chan with data remaining inside
-      std::atomic<size_t> count;
+      std::atomic<size_t> count{0};
       {
         auto chan = tmc::qu_spsc_bounded<
           spsc_destructor_counter, qu_config<PackingLevel>>{TEST_CAPACITY};

--- a/tests/test_qu_spsc_unbounded.cpp
+++ b/tests/test_qu_spsc_unbounded.cpp
@@ -131,7 +131,7 @@ void do_chan_test(Executor& Exec) {
           for (size_t i = 0; i < NITEMS; ++i) {
             auto v = Chan.try_pull();
             while (!v) {
-              TMC_CPU_PAUSE();
+              co_await tmc::reschedule();
               v = Chan.try_pull();
             }
             ++count;
@@ -152,7 +152,7 @@ void do_chan_test(Executor& Exec) {
     }
     {
       // destroy chan with data remaining inside
-      std::atomic<size_t> count;
+      std::atomic<size_t> count{0};
       {
         auto chan = tmc::qu_spsc_unbounded<
           spsc_destructor_counter, qu_config<PackingLevel>>{};


### PR DESCRIPTION
The MacOS Github Actions runner doesn't actually give us 2 cores sometimes, so spinning in a test can cause a timeout. Using `tmc::reschedule()` is a better way to ensure other tasks can run.