### PR TITLE
test that non-forking rvalue awaitables can be safely captured into a task

### DIFF
--- a/tests/test_atomic_condvar.cpp
+++ b/tests/test_atomic_condvar.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <type_traits>
 
 #define CATEGORY test_atomic_condvar
 
@@ -262,6 +263,34 @@ TEST_F(CATEGORY, co_notify_no_symmetric) {
     EXPECT_EQ(tmc::current_priority(), 1);
     co_await aa;
     co_await std::move(t);
+  }());
+}
+
+// The atomic_condvar awaitables are movable so that utility functions
+// (spawn(), fork_group, spawn_group, ...) can capture them by value into a
+// wrapper task. This makes it safe to pass a temporary and defer the
+// co_await.
+static_assert(std::is_move_constructible_v<tmc::aw_atomic_condvar<int>>);
+static_assert(!std::is_copy_constructible_v<tmc::aw_atomic_condvar<int>>);
+static_assert(
+  std::is_move_constructible_v<tmc::aw_atomic_condvar_co_notify<int>>
+);
+static_assert(
+  !std::is_copy_constructible_v<tmc::aw_atomic_condvar_co_notify<int>>
+);
+
+TEST_F(CATEGORY, fork_temporary_await) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    tmc::atomic_condvar<int> cv(1);
+    // The temporary returned by await() is destroyed at the end of this
+    // statement, but the forked wrapper task owns a copy of it, which
+    // suspends until the value changes.
+    auto t = tmc::spawn(cv.await(1)).fork();
+    co_await waiter_count_accessor::wait_for_waiter_count(cv, 1);
+    cv.ref().store(2, std::memory_order_seq_cst);
+    cv.notify_one();
+    co_await std::move(t);
+    co_await waiter_count_accessor::wait_for_waiter_count(cv, 0);
   }());
 }
 

--- a/tests/test_mutex.cpp
+++ b/tests/test_mutex.cpp
@@ -1,11 +1,13 @@
 #include "atomic_awaitable.hpp"
 #include "test_common.hpp"
 #include "tmc/mutex.hpp"
+#include "tmc/spawn_group.hpp"
 #include "waiter_count_accessor.hpp"
 
 #include <gtest/gtest.h>
 
 #include <array>
+#include <type_traits>
 
 #define CATEGORY test_mutex
 
@@ -772,6 +774,72 @@ TEST_F(CATEGORY, co_unlock_return_no_awaiter_or_parent) {
     // This should be resumed with the correct priority.
     EXPECT_EQ(mut.is_locked(), false);
     EXPECT_EQ(tmc::current_priority(), 0);
+  }());
+}
+
+// The mutex awaitables are movable so that utility functions (spawn(),
+// fork_group, spawn_group, ...) can capture them by value into a wrapper
+// task. This makes it safe to pass a temporary and defer the co_await.
+static_assert(std::is_move_constructible_v<tmc::aw_mutex_lock_scope>);
+static_assert(!std::is_copy_constructible_v<tmc::aw_mutex_lock_scope>);
+static_assert(std::is_move_constructible_v<tmc::aw_mutex_co_unlock>);
+static_assert(!std::is_copy_constructible_v<tmc::aw_mutex_co_unlock>);
+static_assert(std::is_move_constructible_v<tmc::aw_mutex_co_unlock_return<int>>);
+
+TEST_F(CATEGORY, fork_temporary_lock_scope) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    tmc::mutex mut;
+    co_await mut;
+    // The temporary returned by lock_scope() is destroyed at the end of this
+    // statement, but the forked wrapper task owns a copy of it, which
+    // suspends on the contended mutex.
+    auto t = tmc::spawn(mut.lock_scope()).fork();
+    co_await waiter_count_accessor::wait_for_waiter_count(mut, 1);
+    mut.unlock();
+    {
+      auto scope = co_await std::move(t);
+      EXPECT_EQ(mut.is_locked(), true);
+    }
+    EXPECT_EQ(mut.is_locked(), false);
+  }());
+}
+
+TEST_F(CATEGORY, task_co_return_lock_scope) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    tmc::mutex mut;
+    // task_promise stores results that are not move-assignable (such as
+    // mutex_scope) by emplacing into the optional result storage.
+    {
+      auto scope =
+        co_await [](tmc::mutex& Mut) -> tmc::task<tmc::mutex_scope> {
+        co_return co_await Mut.lock_scope();
+      }(mut);
+      EXPECT_EQ(mut.is_locked(), true);
+    }
+    EXPECT_EQ(mut.is_locked(), false);
+    {
+      auto scope = co_await tmc::spawn(
+        [](tmc::mutex& Mut) -> tmc::task<tmc::mutex_scope> {
+          co_return co_await Mut.lock_scope();
+        }(mut)
+      );
+      EXPECT_EQ(mut.is_locked(), true);
+    }
+    EXPECT_EQ(mut.is_locked(), false);
+  }());
+}
+
+TEST_F(CATEGORY, spawn_group_temporary_co_unlock) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    tmc::mutex mut;
+    co_await mut;
+    // The spawn_group captures the temporary co_unlock() awaitable by value.
+    // It is not initiated until the group is awaited, well after the
+    // temporary has been destroyed.
+    auto sg = tmc::spawn_group(mut.co_unlock());
+    EXPECT_EQ(mut.is_locked(), true);
+    co_await std::move(sg);
+    EXPECT_EQ(mut.is_locked(), false);
   }());
 }
 

--- a/tests/test_rw_lock.cpp
+++ b/tests/test_rw_lock.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <type_traits>
 #include <vector>
 
 #define CATEGORY test_rw_lock
@@ -522,6 +523,43 @@ TEST_F(CATEGORY, stress) {
     EXPECT_EQ(a, static_cast<size_t>((TASK_COUNT / 4) * ITERS));
     EXPECT_EQ(b, static_cast<size_t>((TASK_COUNT / 4) * ITERS));
     rw.unlock_read();
+  }());
+}
+
+// The rw_lock awaitables are movable so that utility functions (spawn(),
+// fork_group, spawn_group, ...) can capture them by value into a wrapper
+// task. This makes it safe to pass a temporary and defer the co_await.
+static_assert(std::is_move_constructible_v<tmc::aw_rw_lock_read>);
+static_assert(!std::is_copy_constructible_v<tmc::aw_rw_lock_read>);
+static_assert(std::is_move_constructible_v<tmc::aw_rw_lock_write>);
+static_assert(!std::is_copy_constructible_v<tmc::aw_rw_lock_write>);
+static_assert(std::is_move_constructible_v<tmc::aw_rw_lock_read_scope>);
+static_assert(!std::is_copy_constructible_v<tmc::aw_rw_lock_read_scope>);
+static_assert(std::is_move_constructible_v<tmc::aw_rw_lock_write_scope>);
+static_assert(!std::is_copy_constructible_v<tmc::aw_rw_lock_write_scope>);
+
+TEST_F(CATEGORY, fork_temporary_lock_scopes) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    tmc::rw_lock rw;
+    co_await rw.lock_write();
+    // The temporaries returned by lock_read_scope() / lock_write_scope() are
+    // destroyed at the end of their statements, but the forked wrapper tasks
+    // own copies of them, which suspend on the write-locked rw_lock.
+    auto tr = tmc::spawn(rw.lock_read_scope()).fork();
+    co_await waiter_count_accessor::wait_for_waiter_count(rw, 1);
+    auto tw = tmc::spawn(rw.lock_write_scope()).fork();
+    co_await waiter_count_accessor::wait_for_waiter_count(rw, 2);
+    rw.unlock_write();
+    {
+      auto readScope = co_await std::move(tr);
+      EXPECT_EQ(rw.reader_count(), 1u);
+    }
+    EXPECT_EQ(rw.reader_count(), 0u);
+    {
+      auto writeScope = co_await std::move(tw);
+      EXPECT_EQ(rw.is_write_locked(), true);
+    }
+    EXPECT_EQ(rw.is_write_locked(), false);
   }());
 }
 

--- a/tests/test_semaphore.cpp
+++ b/tests/test_semaphore.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <array>
+#include <type_traits>
 
 #define CATEGORY test_semaphore
 
@@ -804,6 +805,34 @@ TEST_F(CATEGORY, co_release_return_no_awaiter_or_parent) {
     // This should be resumed with the correct priority.
     EXPECT_EQ(sem.count(), 1);
     EXPECT_EQ(tmc::current_priority(), 0);
+  }());
+}
+
+// The semaphore awaitables are movable so that utility functions (spawn(),
+// fork_group, spawn_group, ...) can capture them by value into a wrapper
+// task. This makes it safe to pass a temporary and defer the co_await.
+static_assert(std::is_move_constructible_v<tmc::aw_semaphore_acquire_scope>);
+static_assert(!std::is_copy_constructible_v<tmc::aw_semaphore_acquire_scope>);
+static_assert(std::is_move_constructible_v<tmc::aw_semaphore_co_release>);
+static_assert(!std::is_copy_constructible_v<tmc::aw_semaphore_co_release>);
+static_assert(
+  std::is_move_constructible_v<tmc::aw_semaphore_co_release_return<int>>
+);
+
+TEST_F(CATEGORY, fork_temporary_acquire_scope) {
+  test_async_main(ex(), []() -> tmc::task<void> {
+    tmc::semaphore sem(0);
+    // The temporary returned by acquire_scope() is destroyed at the end of
+    // this statement, but the forked wrapper task owns a copy of it, which
+    // suspends on the depleted semaphore.
+    auto t = tmc::spawn(sem.acquire_scope()).fork();
+    co_await waiter_count_accessor::wait_for_waiter_count(sem, 1);
+    sem.release();
+    {
+      auto scope = co_await std::move(t);
+      EXPECT_EQ(sem.count(), 0);
+    }
+    EXPECT_EQ(sem.count(), 1);
   }());
 }
 


### PR DESCRIPTION
Tests for https://github.com/tzcnt/TooManyCooks/pull/271

Because these awaitables are movable, when bound to a task wrapper either implicitly, or via `tmc::as_task`, they are bound as values, so their lifetime is the same as the task.